### PR TITLE
fix(notification_router): handle partial failures in batch_load_and_notify

### DIFF
--- a/src/notification_router.rs
+++ b/src/notification_router.rs
@@ -338,9 +338,12 @@ async fn batch_load_and_notify(
             tracing::warn!(
                 error = %e,
                 n_jobs = unique_ids.len(),
-                "batch_load_and_notify: failed to load job entities"
+                "batch_load_and_notify: find_all failed, falling back to individual loads"
             );
-            // Waiters remain registered — sweep will retry
+            // Fall back to individual loads so one bad job doesn't block the rest
+            for job_id in unique_ids {
+                load_and_notify(waiters, repo, job_id).await;
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

- When `repo.find_all()` fails for an entire batch, **fall back to individual `find_by_id()` calls** so a failure for one job does not block notifications for the rest
- Each individual failure is logged with a warning but processing continues for the remaining jobs
- Successful jobs still get their waiters notified immediately

Addresses Bugbot observation 2 from #76.

## Test plan

- [ ] Existing integration tests pass (happy path unchanged — `find_all` still used as fast path)
- [ ] If `find_all` encounters a transient DB error, individual loads proceed and unrelated waiters are notified

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes notification delivery behavior in the terminal-state path; a `find_all` failure now triggers N individual DB reads, which could affect load/latency and retry semantics under DB errors.
> 
> **Overview**
> Ensures terminal job notifications aren’t blocked when the batched `repo.find_all()` call fails in `batch_load_and_notify`.
> 
> On batch failure, it now logs the fallback and attempts `load_and_notify` per job ID, allowing unaffected jobs’ waiters to be notified immediately instead of waiting for the next sweep.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a7f92887334927b79e336e162d6221514a73d6f3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->