### PR TITLE
feat(spawner): propagate parent_job_id via task-local for external spawners

### DIFF
--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -12,6 +12,10 @@ use super::{
     tracker::JobTracker,
 };
 
+tokio::task_local! {
+    pub(crate) static CURRENT_EXECUTING_JOB_ID: JobId;
+}
+
 #[derive(Debug)]
 pub struct PolledJob {
     pub id: JobId,
@@ -92,7 +96,14 @@ impl JobDispatcher {
             Arc::clone(&self.repo),
         );
         self.tracker.dispatch_job();
-        match Self::dispatch_job(self.runner.take().expect("runner"), current_job).await {
+        let job_id = polled_job.id;
+        match CURRENT_EXECUTING_JOB_ID
+            .scope(
+                job_id,
+                Self::dispatch_job(self.runner.take().expect("runner"), current_job),
+            )
+            .await
+        {
             Err(e) => {
                 span.record("conclusion", "Error");
                 self.fail_job(job.id, e, polled_job.attempt).await?

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -13,6 +13,17 @@ use super::{
 };
 
 tokio::task_local! {
+    /// Holds the [`JobId`] of the currently executing job within a dispatcher
+    /// task. Set via [`CURRENT_EXECUTING_JOB_ID::scope`] before calling
+    /// `runner.run()`, so any [`JobSpawner`] used inside the runner can fall
+    /// back to this value when no explicit `parent_job_id` has been set via
+    /// [`JobSpawner::with_parent`].
+    ///
+    /// **Limitation:** standard tokio task-locals do *not* propagate into
+    /// child tasks created with [`tokio::spawn`]. If a job runner internally
+    /// calls `tokio::spawn(async { spawner.spawn(...) })`, the task-local
+    /// will not be visible and `parent_job_id` will be `None`. Use explicit
+    /// [`JobSpawner::with_parent`] in those cases.
     pub(crate) static CURRENT_EXECUTING_JOB_ID: JobId;
 }
 

--- a/src/spawner.rs
+++ b/src/spawner.rs
@@ -8,6 +8,7 @@ use tracing::instrument;
 
 use super::{
     Job, JobId,
+    dispatcher::CURRENT_EXECUTING_JOB_ID,
     entity::{JobType, NewJob},
     error::JobError,
     repo::JobRepo,
@@ -105,6 +106,11 @@ where
     /// Returns the job type this spawner creates.
     pub fn job_type(&self) -> &JobType {
         &self.job_type
+    }
+
+    fn resolve_parent_job_id(&self) -> Option<JobId> {
+        self.parent_job_id
+            .or_else(|| CURRENT_EXECUTING_JOB_ID.try_with(|id| *id).ok())
     }
 
     /// Create and spawn a job for immediate execution.
@@ -324,7 +330,7 @@ where
                 .job_type(self.job_type.clone())
                 .config(spec.config)?
                 .tracing_context(es_entity::context::TracingContext::current())
-                .parent_job_id(self.parent_job_id)
+                .parent_job_id(self.resolve_parent_job_id())
                 .build()
                 .expect("Could not build new job");
             new_jobs.push(new_job);
@@ -381,7 +387,7 @@ where
             .job_type(self.job_type.clone())
             .config(config)?
             .tracing_context(es_entity::context::TracingContext::current())
-            .parent_job_id(self.parent_job_id)
+            .parent_job_id(self.resolve_parent_job_id())
             .build()
             .expect("Could not build new job");
         let mut op = self.repo.begin_op_with_clock(&self.clock).await?;
@@ -413,7 +419,7 @@ where
             .job_type(self.job_type.clone())
             .config(config)?
             .tracing_context(es_entity::context::TracingContext::current())
-            .parent_job_id(self.parent_job_id)
+            .parent_job_id(self.resolve_parent_job_id())
             .build()
             .expect("Could not build new job");
 

--- a/tests/job.rs
+++ b/tests/job.rs
@@ -1996,3 +1996,314 @@ async fn test_task_local_parent_propagation_with_external_spawner() -> anyhow::R
 
     Ok(())
 }
+
+// -- Explicit with_parent() takes priority over task-local --
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct ExplicitParentConfig {
+    child_id: JobId,
+    explicit_parent_id: JobId,
+}
+
+struct ExplicitParentInitializer {
+    child_spawner: JobSpawner<TaskLocalChildConfig>,
+}
+
+impl JobInitializer for ExplicitParentInitializer {
+    type Config = ExplicitParentConfig;
+
+    fn job_type(&self) -> JobType {
+        JobType::new("explicit-parent-test")
+    }
+
+    fn init(
+        &self,
+        job: &Job,
+        _spawner: JobSpawner<Self::Config>,
+    ) -> Result<Box<dyn JobRunner>, Box<dyn std::error::Error>> {
+        let config: ExplicitParentConfig = job.config()?;
+        Ok(Box::new(ExplicitParentRunner {
+            child_id: config.child_id,
+            explicit_parent_id: config.explicit_parent_id,
+            child_spawner: self.child_spawner.clone(),
+        }))
+    }
+}
+
+struct ExplicitParentRunner {
+    child_id: JobId,
+    explicit_parent_id: JobId,
+    child_spawner: JobSpawner<TaskLocalChildConfig>,
+}
+
+#[async_trait]
+impl JobRunner for ExplicitParentRunner {
+    async fn run(
+        &self,
+        _current_job: CurrentJob,
+    ) -> Result<JobCompletion, Box<dyn std::error::Error>> {
+        // Call with_parent(explicit_id) on the external spawner.
+        // Even though the task-local holds this runner's job ID,
+        // the explicit value should win.
+        self.child_spawner
+            .clone()
+            .with_parent(self.explicit_parent_id)
+            .spawn(self.child_id, TaskLocalChildConfig { value: 99 })
+            .await?;
+        Ok(JobCompletion::Complete)
+    }
+}
+
+#[tokio::test]
+async fn test_explicit_with_parent_takes_priority_over_task_local() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let config = JobSvcConfig::builder()
+        .pool(pool)
+        .build()
+        .expect("Failed to build JobsConfig");
+
+    let mut jobs = Jobs::init(config).await?;
+
+    let child_spawner = jobs.add_initializer(TaskLocalChildInitializer);
+    let parent_spawner = jobs.add_initializer(ExplicitParentInitializer {
+        child_spawner: child_spawner.clone(),
+    });
+
+    jobs.start_poll().await?;
+
+    // Create a real "decoy" job so the FK constraint on parent_job_id is satisfied
+    let explicit_parent_id = JobId::new();
+    child_spawner
+        .spawn(explicit_parent_id, TaskLocalChildConfig { value: 0 })
+        .await?;
+
+    let parent_id = JobId::new();
+    let child_id = JobId::new();
+    parent_spawner
+        .spawn(
+            parent_id,
+            ExplicitParentConfig {
+                child_id,
+                explicit_parent_id,
+            },
+        )
+        .await?;
+
+    jobs.await_completion(parent_id, Some(Duration::from_secs(5)))
+        .await?;
+    jobs.await_completion(child_id, Some(Duration::from_secs(5)))
+        .await?;
+
+    let child = jobs.find(child_id).await?;
+    assert_eq!(
+        child.parent_job_id,
+        Some(explicit_parent_id),
+        "explicit with_parent() should take priority over task-local"
+    );
+    // Confirm it is NOT the task-local value (the running job's ID)
+    assert_ne!(
+        child.parent_job_id,
+        Some(parent_id),
+        "child should not inherit the task-local job ID when explicit parent is set"
+    );
+
+    Ok(())
+}
+
+// -- Nested A→B→C multi-level propagation test --
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct ChainConfig {
+    child_id: JobId,
+}
+
+struct ChainLeafInitializer;
+
+impl JobInitializer for ChainLeafInitializer {
+    type Config = ChainConfig;
+
+    fn job_type(&self) -> JobType {
+        JobType::new("chain-leaf")
+    }
+
+    fn init(
+        &self,
+        _job: &Job,
+        _spawner: JobSpawner<Self::Config>,
+    ) -> Result<Box<dyn JobRunner>, Box<dyn std::error::Error>> {
+        Ok(Box::new(ChainLeafRunner))
+    }
+}
+
+struct ChainLeafRunner;
+
+#[async_trait]
+impl JobRunner for ChainLeafRunner {
+    async fn run(
+        &self,
+        _current_job: CurrentJob,
+    ) -> Result<JobCompletion, Box<dyn std::error::Error>> {
+        Ok(JobCompletion::Complete)
+    }
+}
+
+struct ChainMiddleInitializer {
+    leaf_spawner: JobSpawner<ChainConfig>,
+}
+
+impl JobInitializer for ChainMiddleInitializer {
+    type Config = ChainConfig;
+
+    fn job_type(&self) -> JobType {
+        JobType::new("chain-middle")
+    }
+
+    fn init(
+        &self,
+        job: &Job,
+        _spawner: JobSpawner<Self::Config>,
+    ) -> Result<Box<dyn JobRunner>, Box<dyn std::error::Error>> {
+        let config: ChainConfig = job.config()?;
+        Ok(Box::new(ChainMiddleRunner {
+            child_id: config.child_id,
+            leaf_spawner: self.leaf_spawner.clone(),
+        }))
+    }
+}
+
+struct ChainMiddleRunner {
+    child_id: JobId,
+    leaf_spawner: JobSpawner<ChainConfig>,
+}
+
+#[async_trait]
+impl JobRunner for ChainMiddleRunner {
+    async fn run(
+        &self,
+        _current_job: CurrentJob,
+    ) -> Result<JobCompletion, Box<dyn std::error::Error>> {
+        self.leaf_spawner
+            .spawn(
+                self.child_id,
+                ChainConfig {
+                    child_id: JobId::new(),
+                },
+            )
+            .await?;
+        Ok(JobCompletion::Complete)
+    }
+}
+
+struct ChainRootInitializer {
+    middle_spawner: JobSpawner<ChainConfig>,
+}
+
+impl JobInitializer for ChainRootInitializer {
+    type Config = ChainConfig;
+
+    fn job_type(&self) -> JobType {
+        JobType::new("chain-root")
+    }
+
+    fn init(
+        &self,
+        job: &Job,
+        _spawner: JobSpawner<Self::Config>,
+    ) -> Result<Box<dyn JobRunner>, Box<dyn std::error::Error>> {
+        let config: ChainConfig = job.config()?;
+        Ok(Box::new(ChainRootRunner {
+            child_id: config.child_id,
+            middle_spawner: self.middle_spawner.clone(),
+        }))
+    }
+}
+
+struct ChainRootRunner {
+    child_id: JobId,
+    middle_spawner: JobSpawner<ChainConfig>,
+}
+
+#[async_trait]
+impl JobRunner for ChainRootRunner {
+    async fn run(
+        &self,
+        _current_job: CurrentJob,
+    ) -> Result<JobCompletion, Box<dyn std::error::Error>> {
+        self.middle_spawner
+            .spawn(
+                self.child_id,
+                ChainConfig {
+                    child_id: JobId::new(),
+                },
+            )
+            .await?;
+        Ok(JobCompletion::Complete)
+    }
+}
+
+#[tokio::test]
+async fn test_nested_abc_multi_level_propagation() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let config = JobSvcConfig::builder()
+        .pool(pool)
+        .build()
+        .expect("Failed to build JobsConfig");
+
+    let mut jobs = Jobs::init(config).await?;
+
+    // Register leaf (C), middle (B), root (A) — order matters for spawner wiring
+    let leaf_spawner = jobs.add_initializer(ChainLeafInitializer);
+    let middle_spawner = jobs.add_initializer(ChainMiddleInitializer { leaf_spawner });
+    let root_spawner = jobs.add_initializer(ChainRootInitializer { middle_spawner });
+
+    jobs.start_poll().await?;
+
+    let a_id = JobId::new();
+    let b_id = JobId::new();
+
+    // A's runner will spawn B, B's runner will spawn C
+    // We pass c_id through B's config so B knows which ID to give C
+    root_spawner
+        .spawn(a_id, ChainConfig { child_id: b_id })
+        .await?;
+
+    // Wait for A to complete (it spawns B)
+    jobs.await_completion(a_id, Some(Duration::from_secs(5)))
+        .await?;
+
+    // Now patch B's config: B needs to know c_id.
+    // Actually, B was already spawned by A with a random child_id in ChainConfig.
+    // We need to find B's actual child. Let's wait for B and then check its children.
+    jobs.await_completion(b_id, Some(Duration::from_secs(5)))
+        .await?;
+
+    // Verify A→B→C chain
+    let job_a = jobs.find(a_id).await?;
+    assert!(
+        job_a.parent_job_id.is_none(),
+        "root job A should have no parent"
+    );
+
+    let job_b = jobs.find(b_id).await?;
+    assert_eq!(
+        job_b.parent_job_id,
+        Some(a_id),
+        "B.parent_job_id should be A"
+    );
+
+    // B spawned C with a random ID — find C via parent listing
+    let b_children = jobs.list_all_by_parent_job_id(b_id).await?;
+    assert_eq!(
+        b_children.len(),
+        1,
+        "B should have spawned exactly one child"
+    );
+    let job_c = &b_children[0];
+    assert_eq!(
+        job_c.parent_job_id,
+        Some(b_id),
+        "C.parent_job_id should be B"
+    );
+
+    Ok(())
+}

--- a/tests/job.rs
+++ b/tests/job.rs
@@ -1854,3 +1854,145 @@ async fn test_automatic_parent_propagation() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+// -- Task-local parent propagation tests (external spawner) --
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct TaskLocalChildConfig {
+    value: u32,
+}
+
+struct TaskLocalChildInitializer;
+
+impl JobInitializer for TaskLocalChildInitializer {
+    type Config = TaskLocalChildConfig;
+
+    fn job_type(&self) -> JobType {
+        JobType::new("task-local-child")
+    }
+
+    fn init(
+        &self,
+        _job: &Job,
+        _spawner: JobSpawner<Self::Config>,
+    ) -> Result<Box<dyn JobRunner>, Box<dyn std::error::Error>> {
+        Ok(Box::new(TaskLocalChildRunner))
+    }
+}
+
+struct TaskLocalChildRunner;
+
+#[async_trait]
+impl JobRunner for TaskLocalChildRunner {
+    async fn run(
+        &self,
+        _current_job: CurrentJob,
+    ) -> Result<JobCompletion, Box<dyn std::error::Error>> {
+        Ok(JobCompletion::Complete)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct TaskLocalParentConfig {
+    child_id: JobId,
+}
+
+struct TaskLocalParentInitializer {
+    /// External spawner for the child job type — NOT the init-injected one.
+    child_spawner: JobSpawner<TaskLocalChildConfig>,
+}
+
+impl JobInitializer for TaskLocalParentInitializer {
+    type Config = TaskLocalParentConfig;
+
+    fn job_type(&self) -> JobType {
+        JobType::new("task-local-parent")
+    }
+
+    fn init(
+        &self,
+        job: &Job,
+        _spawner: JobSpawner<Self::Config>,
+    ) -> Result<Box<dyn JobRunner>, Box<dyn std::error::Error>> {
+        let config: TaskLocalParentConfig = job.config()?;
+        Ok(Box::new(TaskLocalParentRunner {
+            child_id: config.child_id,
+            child_spawner: self.child_spawner.clone(),
+        }))
+    }
+}
+
+struct TaskLocalParentRunner {
+    child_id: JobId,
+    child_spawner: JobSpawner<TaskLocalChildConfig>,
+}
+
+#[async_trait]
+impl JobRunner for TaskLocalParentRunner {
+    async fn run(
+        &self,
+        _current_job: CurrentJob,
+    ) -> Result<JobCompletion, Box<dyn std::error::Error>> {
+        // Spawn a child using the EXTERNAL spawner (parent_job_id is None on it).
+        // The task-local should provide the parent_job_id automatically.
+        self.child_spawner
+            .spawn(self.child_id, TaskLocalChildConfig { value: 42 })
+            .await?;
+        Ok(JobCompletion::Complete)
+    }
+}
+
+#[tokio::test]
+async fn test_task_local_parent_propagation_with_external_spawner() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let config = JobSvcConfig::builder()
+        .pool(pool)
+        .build()
+        .expect("Failed to build JobsConfig");
+
+    let mut jobs = Jobs::init(config).await?;
+
+    // Register the child type first to get the external spawner
+    let child_spawner = jobs.add_initializer(TaskLocalChildInitializer);
+
+    // Register the parent type, passing the external child spawner
+    let parent_spawner = jobs.add_initializer(TaskLocalParentInitializer { child_spawner });
+
+    jobs.start_poll().await?;
+
+    // Spawn the parent job
+    let parent_id = JobId::new();
+    let child_id = JobId::new();
+    parent_spawner
+        .spawn(parent_id, TaskLocalParentConfig { child_id })
+        .await?;
+
+    // Wait for both to complete
+    jobs.await_completion(parent_id, Some(Duration::from_secs(5)))
+        .await?;
+    jobs.await_completion(child_id, Some(Duration::from_secs(5)))
+        .await?;
+
+    // The child was spawned by an external spawner (parent_job_id = None),
+    // but the task-local should have propagated the parent's job ID.
+    let child = jobs.find(child_id).await?;
+    assert_eq!(
+        child.parent_job_id,
+        Some(parent_id),
+        "child spawned via external spawner should get parent_job_id from task-local"
+    );
+
+    // Parent should have no parent
+    let parent = jobs.find(parent_id).await?;
+    assert!(
+        parent.parent_job_id.is_none(),
+        "externally-spawned parent job should have no parent"
+    );
+
+    // Verify listing works
+    let children = jobs.list_all_by_parent_job_id(parent_id).await?;
+    assert_eq!(children.len(), 1);
+    assert_eq!(children[0].id, child_id);
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- Declares a `tokio::task_local!` (`CURRENT_EXECUTING_JOB_ID`) in the dispatcher that holds the running job's ID during `runner.run()`
- Adds `resolve_parent_job_id()` to `JobSpawner` — prefers explicit `with_parent()` value, falls back to task-local
- Enables external spawners (not from `init()`) to automatically inherit the parent job ID — matching the pattern used in lana-bank where initializers discard the init-injected spawner

## Motivation
PR #75 added auto-propagation via the init()-injected spawner. However, in lana-bank initializers discard that spawner because they spawn **different** job types using externally-held spawners. Those external spawners had `parent_job_id = None`, so all child jobs ended up with `parent_job_id = NULL`.

The task-local approach fixes this: any spawner called within a job runner's `run()` method automatically gets the parent from the task-local context.

## Changes
- **`src/dispatcher.rs`**: Declare `CURRENT_EXECUTING_JOB_ID` task-local; wrap `dispatch_job()` in `.scope(job_id, ...)`
- **`src/spawner.rs`**: Add `resolve_parent_job_id()` helper; use it in `create_job_internal()`, `spawn_all_in_op()`, and `spawn_unique()`
- **`tests/job.rs`**: New integration test proving external spawners get parent_job_id via task-local

## Backward Compatibility
- Explicit `with_parent()` still takes priority (no behavior change)
- Init-injected spawners still work (have explicit parent from PR #75)
- Spawners used outside a job runner context get `parent_job_id = None` (task-local not set)

## Test plan
- [x] `cargo fmt` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo nextest run` — 56/56 tests pass
- [x] `nix flake check` passes
- [x] New test `test_task_local_parent_propagation_with_external_spawner` validates the exact lana-bank pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)