### PR TITLE
chore: add fly to devshell, make crate publish idempotent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -421,9 +421,9 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "es-entity"
-version = "0.10.32"
+version = "0.10.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4d3abcd7ae89ef1bebe59d927639baea3ac18d2f49697d452e058d9d853ec7f"
+checksum = "453a8768e97e3363d74a307e466a1a437765088bad5b5a49bdba3f72c64ae854"
 dependencies = [
  "chrono",
  "derive_builder",
@@ -446,9 +446,9 @@ dependencies = [
 
 [[package]]
 name = "es-entity-macros"
-version = "0.10.32"
+version = "0.10.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f21f3a1133b72c6b18039ef807b4f5af9b70da7fea3265c1d69f06994fd7b68b"
+checksum = "31b7f9832d1cb8219f8df5a5d5f24b19b8df68985d3f32667e4d9bbfe9f29a33"
 dependencies = [
  "convert_case",
  "darling 0.23.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ anyhow = { workspace = true }
 
 [workspace.dependencies]
 
-es-entity = "0.10.32"
+es-entity = "0.10.33"
 
 anyhow = "1.0"
 async-trait = "0.1"

--- a/ci/tasks/publish-to-crates.sh
+++ b/ci/tasks/publish-to-crates.sh
@@ -2,10 +2,24 @@
 
 set -e
 
+publish_crate() {
+  local crate=$1
+  local output
+  if output=$(cargo publish -p "$crate" --all-features --no-verify 2>&1); then
+    echo "Published $crate"
+  elif echo "$output" | grep -q "already exists"; then
+    echo "Skipping $crate - version already published"
+  else
+    echo "$output"
+    echo "Failed to publish $crate"
+    return 1
+  fi
+}
+
 pushd repo
 
 cat <<EOF | cargo login
 ${CRATES_API_TOKEN}
 EOF
 
-cargo publish -p job --all-features --no-verify
+publish_crate job

--- a/flake.nix
+++ b/flake.nix
@@ -71,6 +71,7 @@
         podman
         podman-compose
         curl
+        fly
       ];
       devEnvVars = rec {
         PGDATABASE = "pg";


### PR DESCRIPTION
## Summary
- Add `fly` CLI to nix devshell `nativeBuildInputs` to keep in sync with Concourse target (8.0.1)
- Make crate publishing idempotent — skip already-published versions instead of failing

## Test plan
- [ ] Verify `fly` is available in nix shell
- [ ] Verify release pipeline handles already-published crates gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)