### PR TITLE
chore(config): increase default job limits per process

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -155,11 +155,11 @@ fn default_job_lost_interval() -> Duration {
 }
 
 fn default_max_jobs_per_process() -> usize {
-    50
+    75
 }
 
 fn default_min_jobs_per_process() -> usize {
-    30
+    50
 }
 
 fn default_shutdown_timeout() -> Duration {


### PR DESCRIPTION
Raise max_jobs_per_process from 50 to 75 and min_jobs_per_process from 30 to 50.