### PR TITLE
fix(ci): replace cachix with magic-nix-cache-action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,10 +11,8 @@ jobs:
     steps:
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v16
-      - uses: cachix/cachix-action@v15
-        with:
-          name: lana-ci
-          authToken: ${{ env.CACHIX_AUTH_TOKEN }}
+      - name: Run the Magic Nix Cache
+        uses: DeterminateSystems/magic-nix-cache-action@v8
       - uses: actions/checkout@v3
       - name: Run integration tests
         run: nix run .#nextest


### PR DESCRIPTION
## Summary
- Replace `cachix/cachix-action` (using defunct `lana-ci` cache) with `DeterminateSystems/magic-nix-cache-action`
- The `lana-ci` Cachix cache became inaccessible around April 2nd, breaking all CI runs
- `magic-nix-cache-action` uses GitHub Actions cache storage and requires no external token

## Test plan
- [ ] Verify this PR's own CI passes (the test workflow should no longer fail on cachix)