### PR TITLE
fix(poller): wake main loop on wall clock to survive frozen manual clocks

### DIFF
--- a/src/poller.rs
+++ b/src/poller.rs
@@ -164,8 +164,21 @@ impl JobPoller {
                 _ = shutdown_rx.recv() => {
                     break;
                 }
-                result = self.clock.timeout(timeout, self.tracker.notified()) => {
-                    woken_up = result.is_ok();
+                _ = self.tracker.notified() => {
+                    woken_up = true;
+                }
+                // Clock-driven sleep honours manual-clock advance() jumps so
+                // `WaitTillNextJob` delays resolve as soon as simulated time
+                // catches up, matching prior behaviour under artificial clocks.
+                _ = self.clock.sleep(timeout) => {
+                    woken_up = false;
+                }
+                // Wall-clock safety net, capped at MAX_WAIT. Ensures the poller
+                // re-evaluates tracker/DB state at least every 60s of real time
+                // even when the application clock is simulated and frozen
+                // (e.g. manual-clock deployments between user-driven advances).
+                _ = tokio::time::sleep(std::cmp::min(timeout, MAX_WAIT)) => {
+                    woken_up = false;
                 }
             }
         }

--- a/tests/job.rs
+++ b/tests/job.rs
@@ -2074,3 +2074,99 @@ async fn test_lost_handler_rescues_other_instance_jobs() -> anyhow::Result<()> {
     jobs.shutdown().await?;
     Ok(())
 }
+
+/// Verify that the main poll loop's safety-net timeout is wall-clock driven
+/// (not application-clock driven), so a manual clock that never advances
+/// cannot wedge the dispatcher.
+///
+/// Scenario: manual clock, never advanced. A pending job row is inserted
+/// directly into `job_executions` with the NOTIFY trigger disabled — so no PG
+/// NOTIFY fires and the tracker is never notified that work exists. The only
+/// mechanism left to pick the row up is the main loop's periodic fallback
+/// poll. Under the previous `self.clock.timeout(MAX_WAIT, …)` implementation
+/// this fallback was gated on simulated time and would never fire; with the
+/// wall-clock fallback it must fire within ~MAX_WAIT seconds of real time.
+#[tokio::test]
+async fn test_main_loop_falls_back_to_wall_clock_under_frozen_manual_clock() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    // Manual clock, deliberately never advanced.
+    let (clock, _controller) = ClockHandle::manual();
+
+    let config = JobSvcConfig::builder()
+        .pool(pool.clone())
+        .clock(clock.clone())
+        .build()
+        .expect("build JobsConfig");
+
+    let mut jobs = Jobs::init(config).await?;
+    let job_type = JobType::new("wall-clock-fallback");
+    let _spawner = jobs.add_initializer(TestJobInitializer {
+        job_type: job_type.clone(),
+    });
+
+    jobs.start_poll().await?;
+
+    // Give the poller's first iteration time to complete and park. Without
+    // this, the test would pick up the new row during startup rather than
+    // exercising the parked-mid-loop fallback path.
+    tokio::time::sleep(tokio::time::Duration::from_millis(250)).await;
+
+    // Insert a pending job directly, with the job_events notify trigger
+    // disabled for the transaction. This simulates a lost notification (e.g.
+    // a listener reconnect gap): the row exists in the DB but the tracker is
+    // never notified, so the only way the poller can discover it is via a
+    // periodic fallback poll.
+    let job_id = JobId::new();
+    let now = clock.now();
+    let mut tx = pool.begin().await?;
+    sqlx::query("ALTER TABLE job_executions DISABLE TRIGGER job_executions_notify_event_trigger")
+        .execute(&mut *tx)
+        .await?;
+    sqlx::query(
+        "INSERT INTO jobs (id, unique_per_type, job_type, created_at) VALUES ($1, false, $2, $3)",
+    )
+    .bind(job_id)
+    .bind(job_type.as_str())
+    .bind(now)
+    .execute(&mut *tx)
+    .await?;
+    sqlx::query(
+        r#"
+        INSERT INTO job_executions
+            (id, job_type, state, alive_at, execute_at, execution_state_json, attempt_index, created_at)
+        VALUES ($1, $2, 'pending', $3, $3, '{}', 1, $3)
+        "#,
+    )
+    .bind(job_id)
+    .bind(job_type.as_str())
+    .bind(now)
+    .execute(&mut *tx)
+    .await?;
+    sqlx::query("ALTER TABLE job_executions ENABLE TRIGGER job_executions_notify_event_trigger")
+        .execute(&mut *tx)
+        .await?;
+    tx.commit().await?;
+
+    // Wait for the fallback poll to pick the row up. With the wall-clock
+    // fallback the main loop re-polls within MAX_WAIT (60s). We give the test
+    // a generous budget but fail fast if we blow past MAX_WAIT.
+    let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_secs(80);
+    loop {
+        tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+        let state: (String,) =
+            sqlx::query_as("SELECT state::text FROM job_executions WHERE id = $1")
+                .bind(job_id)
+                .fetch_one(&pool)
+                .await?;
+        if state.0 != "pending" {
+            break;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "poller did not pick up pending job under frozen manual clock"
+        );
+    }
+
+    jobs.shutdown().await?;
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- The main poll loop's safety-net timeout was gated on `self.clock.timeout`. Under an application clock that doesn't advance (e.g. lana-bank staging running with `enable_artificial_time = true`), the fallback wake never fires, so once the tracker reaches `min_jobs_per_process` the dispatcher is effectively wedged between operator-driven clock advances.
- Replace the single clock-based timeout with a `tokio::select!` that wakes on **any** of shutdown, `tracker.notified()`, `self.clock.sleep(timeout)` (preserves artificial-clock behaviour), or `tokio::time::sleep(min(timeout, MAX_WAIT))` (new wall-clock safety net, capped at 60s).
- Add a regression test covering the frozen-manual-clock wedge.

## Why the wedge happens

`JobTracker::notified()` fires on a narrow condition:

```rust
if rescheduled || n_running_jobs == self.min_jobs {
    self.notify.notify_one();
}
```

Any state that pins `running_jobs` at or above `min_jobs` without a clean boundary crossing — a leaked counter, a lost PG NOTIFY across a listener reconnect, or simply a burst of permanent listener-style jobs sitting at the `min_jobs` boundary — leaves the main loop entirely dependent on a wall-time-independent timeout. With a real-time clock that timeout still fires every 60s as expected. With a manual clock between `advance()` calls it never fires and the poller sleeps forever.

Observed on lana-bank staging: `job.create_internal` fires steadily, `job.dispatch_job` / `job.execute_job` drop to 0 within ~10 minutes of pod start, `job.check_stale_pending_jobs` also goes silent. A pod restart recovers it, and the cycle repeats.

## What changed

`src/poller.rs` main loop:

```rust
tokio::select! {
    biased;
    _ = shutdown_rx.recv() => { break; }
    _ = self.tracker.notified() => { woken_up = true; }
    // Clock-driven sleep keeps manual-clock advance() wakeups instant,
    // matching prior behaviour under artificial clocks.
    _ = self.clock.sleep(timeout) => { woken_up = false; }
    // Wall-clock safety net: re-evaluate tracker/DB state at least every
    // MAX_WAIT of real time, independent of the application clock.
    _ = tokio::time::sleep(std::cmp::min(timeout, MAX_WAIT)) => { woken_up = false; }
}
```

The clock-driven branch is retained so scheduled-job behaviour under manual clocks is unchanged; the wall-clock branch is a defensive upper bound.

## Test plan

- [x] `cargo nextest run` — all 58 tests pass (including the 2 pre-existing `*_with_artificial_clock` tests)
- [x] `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`
- [x] New `test_main_loop_falls_back_to_wall_clock_under_frozen_manual_clock`: inserts a pending row with the `job_events` NOTIFY trigger disabled inside a transaction and deliberately never advances the manual clock. Passes in ≤ `MAX_WAIT` (60s). Verified the test fails in ~80s (times out) when the wall-clock branch is replaced with `std::future::pending()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the core poller main-loop wakeup logic; incorrect select ordering or timing could change dispatch cadence or increase wakeups under load, though the change is bounded and covered by a regression test.
> 
> **Overview**
> Prevents the job poller main loop from getting stuck when an application/manual clock is frozen by splitting the previous clock-based timeout into separate wake conditions.
> 
> The main loop now wakes on `tracker.notified()`, application-clock sleep (`self.clock.sleep(timeout)`) *and* a new wall-clock fallback (`tokio::time::sleep(min(timeout, MAX_WAIT))`), ensuring it re-polls at least every 60s of real time regardless of simulated time.
> 
> Adds a regression test that runs with a manual clock that never advances and inserts a pending `job_executions` row with the PG NOTIFY trigger disabled, asserting the poller still picks it up via the wall-clock fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4fb77d7687ab4f2df81959a5697d51fa12670d56. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->