### PR TITLE
fix(poller): use Instrument to avoid span.enter() across .await

### DIFF
--- a/src/poller.rs
+++ b/src/poller.rs
@@ -2,7 +2,7 @@ use es_entity::AtomicOperation;
 use es_entity::clock::ClockHandle;
 use serde_json::Value as JsonValue;
 use sqlx::postgres::{PgPool, types::PgInterval};
-use tracing::{Span, instrument};
+use tracing::{Instrument, Span, instrument};
 
 use std::{
     sync::{
@@ -233,9 +233,9 @@ impl JobPoller {
                     instance_id = %instance_id,
                     n_lost_jobs = tracing::field::Empty,
                 );
-                let _guard = span.enter();
 
-                if let Ok(rows) = sqlx::query!(
+                async {
+                    if let Ok(rows) = sqlx::query!(
                         r#"
                         UPDATE job_executions
                         SET state = 'pending', execute_at = $1, attempt_index = attempt_index + 1, poller_instance_id = NULL
@@ -259,6 +259,9 @@ impl JobPoller {
                     } else {
                         Span::current().record("n_lost_jobs", 0);
                     }
+                }
+                .instrument(span)
+                .await;
             }
         }))
     }
@@ -281,31 +284,34 @@ impl JobPoller {
                         now = %now,
                         failures
                     );
-                    let _guard = span.enter();
 
-                    let timeout = match sqlx::query!(
-                        r#"
+                    let timeout = async {
+                        match sqlx::query!(
+                            r#"
                         UPDATE job_executions
                         SET alive_at = $1
                         WHERE poller_instance_id = $2 AND state = 'running'
                         "#,
-                        now,
-                        instance_id,
-                    )
-                    .execute(&pool)
-                    .await
-                    {
-                        Ok(_) => {
-                            failures = 0;
-                            job_lost_interval / 4
+                            now,
+                            instance_id,
+                        )
+                        .execute(&pool)
+                        .await
+                        {
+                            Ok(_) => {
+                                failures = 0;
+                                job_lost_interval / 4
+                            }
+                            Err(e) => {
+                                failures += 1;
+                                tracing::error!(instance_id = %instance_id, error = %e, "keep alive error");
+                                Duration::from_millis(50 << failures)
+                            }
                         }
-                        Err(e) => {
-                            failures += 1;
-                            tracing::error!(instance_id = %instance_id, error = %e, "keep alive error");
-                            Duration::from_millis(50 << failures)
-                        }
-                    };
-                    drop(_guard);
+                    }
+                    .instrument(span)
+                    .await;
+
                     clock.sleep_coalesce(timeout).await;
                 }
             }
@@ -330,10 +336,10 @@ impl JobPoller {
                         n_stale_pending = tracing::field::Empty,
                         max_pending_duration_secs = tracing::field::Empty,
                     );
-                    let _guard = span.enter();
 
-                    match sqlx::query!(
-                        r#"
+                    async {
+                        match sqlx::query!(
+                            r#"
                         SELECT
                             job_type,
                             COUNT(*)::INT4 AS "count!: i32",
@@ -345,36 +351,40 @@ impl JobPoller {
                         AND job_type = ANY($2)
                         GROUP BY job_type
                         "#,
-                        now,
-                        &supported_job_types as _,
-                    )
-                    .fetch_all(&pool)
-                    .await
-                    {
-                        Ok(rows) => {
-                            let mut total_stale: i64 = 0;
-                            let mut max_pending_secs: f64 = 0.0;
+                            now,
+                            &supported_job_types as _,
+                        )
+                        .fetch_all(&pool)
+                        .await
+                        {
+                            Ok(rows) => {
+                                let mut total_stale: i64 = 0;
+                                let mut max_pending_secs: f64 = 0.0;
 
-                            for row in &rows {
-                                total_stale += row.count as i64;
-                                if row.max_pending_duration_secs > max_pending_secs {
-                                    max_pending_secs = row.max_pending_duration_secs;
+                                for row in &rows {
+                                    total_stale += row.count as i64;
+                                    if row.max_pending_duration_secs > max_pending_secs {
+                                        max_pending_secs = row.max_pending_duration_secs;
+                                    }
+                                    tracing::warn!(
+                                        job_type = %row.job_type,
+                                        count = row.count,
+                                        max_pending_duration_secs = row.max_pending_duration_secs,
+                                        "stale pending jobs detected"
+                                    );
                                 }
-                                tracing::warn!(
-                                    job_type = %row.job_type,
-                                    count = row.count,
-                                    max_pending_duration_secs = row.max_pending_duration_secs,
-                                    "stale pending jobs detected"
-                                );
-                            }
 
-                            Span::current().record("n_stale_pending", total_stale);
-                            Span::current().record("max_pending_duration_secs", max_pending_secs);
-                        }
-                        Err(e) => {
-                            tracing::error!(error = %e, "failed to check stale pending jobs");
+                                Span::current().record("n_stale_pending", total_stale);
+                                Span::current()
+                                    .record("max_pending_duration_secs", max_pending_secs);
+                            }
+                            Err(e) => {
+                                tracing::error!(error = %e, "failed to check stale pending jobs");
+                            }
                         }
                     }
+                    .instrument(span)
+                    .await;
                 }
             }
         ))


### PR DESCRIPTION
## Issue

All three background handlers in `poller.rs` — `start_lost_handler`, `start_keep_alive_handler`, `start_stale_jobs_handler` — use the same shape:

```rust
let _guard = span.enter();
// ...
some_query().await;
// ...
Span::current().record(...);
```

Holding a `tracing::Entered` guard across `.await` on a multi-worker tokio runtime is a well-known async-tracing antipattern (explicitly called out in the [`Span::enter` docs](https://docs.rs/tracing/latest/tracing/struct.Span.html#in-asynchronous-code)). When the task yields and resumes on a different worker, the thread-local current-span stack diverges from the future's internal state. Combined with a layer that keeps per-span state (e.g. `tracing-opentelemetry`), this races `Registry::try_close` and can trip the assertion in `tracing-subscriber`'s sharded registry:

```
thread 'tokio-rt-worker' panicked at tracing-subscriber/src/registry/sharded.rs:317:
assertion `left != right` failed: tried to clone a span (Id(...)) that already closed
```

## Observed in lana-bank

[GaloyMoney/lana-bank](https://github.com/GaloyMoney/lana-bank) runs `job = 0.6.18`, `tracing-subscriber = 0.3.23`, `tracing-opentelemetry = 0.32.1`. Staging logs show the panic firing inside `job.check_stale_pending_jobs` right as it emits `stale pending jobs detected`, caught by the tracing panic hook:

```
ERROR job.check_stale_pending_jobs:panic: panic: Unhandled panic in application
  panic_message = assertion `left != right` failed: tried to clone a span (Id(986289417905766428)) that already closed
  panic_location = .../tracing-subscriber-0.3.23/src/registry/sharded.rs:317
  panic_thread   = "tokio-rt-worker"
```

Impact: the affected poller task dies; the rest of the process keeps running, so recovery is "silent but degraded" until the next deploy. Reproduced outside lana with a ~250-line binary that mirrors the subscriber stack and runs the same `enter()` + `.await` shape — panic fires within ~2 s at 200 tasks on 2 worker threads, identical signature.

## Fix

For each of the three handlers: replace `let _guard = span.enter(); … .await` with `async { … }.instrument(span).await`. The span now follows the future across worker hops via the `Instrument` trait instead of relying on thread-local state. No behavioural changes; SQL text, span names/fields, and the `.sqlx` offline cache are all preserved.
