### PR TITLE
chore: Remove err from instrumentation

### DIFF
--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -50,8 +50,8 @@ impl JobDispatcher {
     }
 
     #[instrument(name = "job.execute_job", skip_all,
-        fields(job_id, job_type, attempt, error, error.level, error.message, conclusion, now),
-    err)]
+        fields(job_id, job_type, attempt, error, error.level, error.message, conclusion, now)
+    )]
     #[cfg_attr(feature = "es-entity", es_entity::es_event_context)]
     pub async fn execute_job(
         mut self,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -645,7 +645,7 @@ impl Jobs {
     ///
     /// If not called manually, shutdown will be automatically triggered when the
     /// Jobs instance is dropped.
-    #[instrument(name = "job.shutdown", skip(self), err)]
+    #[instrument(name = "job.shutdown", skip(self))]
     pub async fn shutdown(&self) -> Result<(), JobError> {
         if let Some(handle) = &self.poller_handle {
             handle.shutdown().await?;

--- a/src/poller.rs
+++ b/src/poller.rs
@@ -175,8 +175,7 @@ impl JobPoller {
         name = "job.poll_and_dispatch",
         level = "debug",
         skip(self),
-        fields(poller_id, n_jobs_running, n_jobs_to_start, now, next_poll_in),
-        err
+        fields(poller_id, n_jobs_running, n_jobs_to_start, now, next_poll_in)
     )]
     async fn poll_and_dispatch(self: &Arc<Self>, woken_up: bool) -> Result<Duration, JobError> {
         let span = Span::current();
@@ -393,8 +392,7 @@ impl JobPoller {
     #[instrument(
         name = "job.dispatch_job",
         skip(self, polled_job),
-        fields(job_id, job_type, poller_id, attempt, now),
-        err
+        fields(job_id, job_type, poller_id, attempt, now)
     )]
     async fn dispatch_job(&self, polled_job: PolledJob) -> Result<(), JobError> {
         let span = Span::current();
@@ -503,7 +501,7 @@ impl JobPoller {
     }
 }
 
-#[instrument(name = "job.poll_jobs", level = "debug", skip(pool, supported_job_types, clock), fields(n_jobs_to_poll, instance_id = %instance_id, n_jobs_found = tracing::field::Empty), err)]
+#[instrument(name = "job.poll_jobs", level = "debug", skip(pool, supported_job_types, clock), fields(n_jobs_to_poll, instance_id = %instance_id, n_jobs_found = tracing::field::Empty))]
 async fn poll_jobs(
     pool: &PgPool,
     n_jobs_to_poll: usize,
@@ -780,7 +778,7 @@ async fn perform_shutdown(
     kill_remaining_jobs(repo, instance_id, clock).await
 }
 
-#[instrument(name = "jobs.kill_remaining_jobs", skip(repo, clock), fields(instance_id = %instance_id, n_killed = tracing::field::Empty), err)]
+#[instrument(name = "jobs.kill_remaining_jobs", skip(repo, clock), fields(instance_id = %instance_id, n_killed = tracing::field::Empty))]
 async fn kill_remaining_jobs(
     repo: Arc<JobRepo>,
     instance_id: uuid::Uuid,

--- a/src/spawner.rs
+++ b/src/spawner.rs
@@ -111,8 +111,7 @@ where
     #[instrument(
         name = "job_spawner.spawn",
         skip(self, config),
-        fields(job_type = %self.job_type),
-        err
+        fields(job_type = %self.job_type)
     )]
     pub async fn spawn(
         &self,
@@ -129,8 +128,7 @@ where
     #[instrument(
         name = "job_spawner.spawn_in_op",
         skip(self, op, config),
-        fields(job_type = %self.job_type),
-        err
+        fields(job_type = %self.job_type)
     )]
     pub async fn spawn_in_op(
         &self,
@@ -146,8 +144,7 @@ where
     #[instrument(
         name = "job_spawner.spawn_at",
         skip(self, config),
-        fields(job_type = %self.job_type),
-        err
+        fields(job_type = %self.job_type)
     )]
     pub async fn spawn_at(
         &self,
@@ -167,8 +164,7 @@ where
     #[instrument(
         name = "job_spawner.spawn_at_in_op",
         skip(self, op, config),
-        fields(job_type = %self.job_type),
-        err
+        fields(job_type = %self.job_type)
     )]
     pub async fn spawn_at_in_op(
         &self,
@@ -187,8 +183,7 @@ where
     #[instrument(
         name = "job_spawner.spawn_with_queue_id",
         skip(self, config, queue_id),
-        fields(job_type = %self.job_type),
-        err
+        fields(job_type = %self.job_type)
     )]
     pub async fn spawn_with_queue_id(
         &self,
@@ -210,8 +205,7 @@ where
     #[instrument(
         name = "job_spawner.spawn_with_queue_id_in_op",
         skip(self, op, config, queue_id),
-        fields(job_type = %self.job_type),
-        err
+        fields(job_type = %self.job_type)
     )]
     pub async fn spawn_with_queue_id_in_op(
         &self,
@@ -231,8 +225,7 @@ where
     #[instrument(
         name = "job_spawner.spawn_at_with_queue_id",
         skip(self, config, queue_id),
-        fields(job_type = %self.job_type),
-        err
+        fields(job_type = %self.job_type)
     )]
     pub async fn spawn_at_with_queue_id(
         &self,
@@ -256,8 +249,7 @@ where
     #[instrument(
         name = "job_spawner.spawn_at_with_queue_id_in_op",
         skip(self, op, config, queue_id),
-        fields(job_type = %self.job_type),
-        err
+        fields(job_type = %self.job_type)
     )]
     pub async fn spawn_at_with_queue_id_in_op(
         &self,
@@ -278,8 +270,7 @@ where
     #[instrument(
         name = "job_spawner.spawn_all",
         skip(self, specs),
-        fields(job_type = %self.job_type),
-        err
+        fields(job_type = %self.job_type)
     )]
     pub async fn spawn_all(&self, specs: Vec<JobSpec<Config>>) -> Result<Vec<Job>, JobError> {
         let mut op = self.repo.begin_op_with_clock(&self.clock).await?;
@@ -295,8 +286,7 @@ where
     #[instrument(
         name = "job_spawner.spawn_all_in_op",
         skip(self, op, specs),
-        fields(job_type = %self.job_type, count),
-        err
+        fields(job_type = %self.job_type, count)
     )]
     pub async fn spawn_all_in_op(
         &self,
@@ -367,8 +357,7 @@ where
     #[instrument(
         name = "job_spawner.spawn_unique",
         skip(self, config),
-        fields(job_type = %self.job_type),
-        err
+        fields(job_type = %self.job_type)
     )]
     pub async fn spawn_unique(
         self,
@@ -398,7 +387,7 @@ where
         Ok(())
     }
 
-    #[instrument(name = "job.create_internal", skip(self, op, config), fields(job_type = %self.job_type), err)]
+    #[instrument(name = "job.create_internal", skip(self, op, config), fields(job_type = %self.job_type))]
     async fn create_job_internal<C: Serialize + Send>(
         &self,
         op: &mut impl es_entity::AtomicOperation,
@@ -423,7 +412,7 @@ where
         Ok(job)
     }
 
-    #[instrument(name = "job.insert_execution", skip_all, err)]
+    #[instrument(name = "job.insert_execution", skip_all)]
     async fn insert_execution(
         &self,
         op: &mut impl es_entity::AtomicOperation,


### PR DESCRIPTION
This is a low-level library, when to emit error events should be up to callers.

The `err` is removed from `instrument` from everywhere.