### PR TITLE
fix(poller): use wall-clock sleep in stale-pending-jobs checker

### DIFF
--- a/src/poller.rs
+++ b/src/poller.rs
@@ -333,7 +333,10 @@ impl JobPoller {
             "job-poller-stale-jobs-handler",
             async move {
                 loop {
-                    clock.sleep_coalesce(pending_jobs_check_interval).await;
+                    // Staleness reporting is a wall-clock concern — a manual clock
+                    // advance should not immediately fire the stale checker before
+                    // the poller has had a chance to pick up newly-eligible jobs.
+                    tokio::time::sleep(pending_jobs_check_interval).await;
                     let now = clock.now();
 
                     let span = tracing::info_span!(


### PR DESCRIPTION
## What's happening

On every lana-bank staging deployment, the following sequence fires:

1. A simulation pod runs loan scenarios at fake clock **Jan 3**, spawning `command.dw-outbox-relay.insert` jobs with `execute_at = Jan 3`
2. The simulation immediately advances the fake clock to **Jan 4** — without waiting for those jobs to be picked up by the poller
3. Both the stale checker and the poller wake up via `clock.sleep_coalesce` **at the same instant**
4. The stale checker wins the race — it just runs a query. It finds `dw-outbox-relay.insert` with `execute_at = Jan 3` and `clock.now() = Jan 4`, reports `max_pending_duration_secs = 86400`
5. Honeycomb alert fires: `n_stale_pending > 0` and `max_pending_duration_secs > 60`
6. A few seconds later the poller picks up the jobs — nothing was actually stuck

**This is a false positive on every single deployment.** The jobs are never genuinely stuck.

## Concrete evidence

From Honeycomb staging traces (`galoy-staging-lana-bank` dataset, span `job.check_stale_pending_jobs`):

| Timestamp | Job type | `max_pending_duration_secs` | `n_stale_pending` |
|---|---|---|---|
| 07:26:52 | `command.dw-outbox-relay.insert` | **86400** ← fires alert | 2 |
| 07:26:52 | `cron.core-time-event.end-of-day-producer` | 0 | 2 |
| 07:27:04 | `cron.core-time-event.end-of-day-producer` | 0 | 1 |

The `86400` (exactly 1 day) is the fake-clock gap between Jan 3 (`execute_at`) and Jan 4 (`clock.now()`). It drops to 0 seconds later once the poller picks them up.

This pattern repeats on every deployment at the exact time the simulation advances the clock (correlated with Concourse build timestamps).

## The fix

`start_stale_jobs_handler` used `clock.sleep_coalesce()`, so it woke up the instant the fake clock advanced — same as the poller, creating the race.

Switching to `tokio::time::sleep()` means the stale checker only wakes on real wall-clock intervals. When the simulation jumps the fake clock, only the poller wakes and picks up the jobs. By the time the stale checker runs (up to 5 real minutes later), the jobs are already gone.

This is the same approach PR #100 took for the keep-alive and lost handlers — staleness reporting is a wall-clock concern, not an application-clock concern.

## Scenarios

**Before fix**: simulation advances clock → stale checker + poller both wake instantly → stale checker fires alert → poller picks up job 2 seconds later → alert was a false positive

**After fix**: simulation advances clock → only poller wakes → picks up job → stale checker wakes 5 minutes later on real time → nothing stale → no alert