### PR TITLE
chore: update dependabot policy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,4 +8,10 @@ updates:
 - package-ecosystem: "cargo"
   directory: "/"
   schedule:
-    interval: "daily"
+    interval: "weekly"
+  cooldown:
+    default-days: 7
+  groups:
+    all-dependencies:
+      patterns:
+        - "*"


### PR DESCRIPTION
## Summary
- change Cargo Dependabot updates from daily to weekly
- add a 7-day cooldown
- group all dependency updates together

## Testing
- not run (configuration-only change)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Configuration-only change to Dependabot scheduling and grouping; low risk aside from potentially delaying visibility of dependency updates.
> 
> **Overview**
> Adjusts `.github/dependabot.yml` to reduce Dependabot noise by switching Cargo updates from *daily* to *weekly*.
> 
> Adds a **7-day cooldown** and groups all dependency updates under `groups.all-dependencies` so updates are bundled together.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e86c82172aefe053e60649890f59e8df45d1aa6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->