### PR TITLE
chore: ignore release-chain crates in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,3 +15,5 @@ updates:
     all-dependencies:
       patterns:
         - "*"
+  ignore:
+    - dependency-name: "es-entity*"


### PR DESCRIPTION
## Summary

Add `es-entity*` to job's dependabot ignore list. These are bumped manually via the `/lana-release-crate-chain` workflow, so dependabot PRs for them would race the manual chain release.

Mirrors the existing policy in cala and the companion PR on obix (GaloyMoney/obix#61).

## Test plan

- [ ] Confirm CI passes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that just suppresses Dependabot update PRs for `es-entity*`, with no runtime code impact.
> 
> **Overview**
> Updates `.github/dependabot.yml` to **ignore** cargo dependencies matching `es-entity*`, preventing Dependabot from opening version-bump PRs for those crates while leaving the rest of the weekly dependency update behavior unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a264a317be565dc8e15bdd352972126020da1bff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->