### PR TITLE
fix: use OTel exception.* fields instead of colliding `error` in error logs

### DIFF
--- a/src/notification_router.rs
+++ b/src/notification_router.rs
@@ -106,7 +106,11 @@ impl JobNotificationRouter {
                         }
                     }
                     Err(e) => {
-                        tracing::error!(error = %e, "job notification listener error");
+                        tracing::error!(
+                            exception.message = %e,
+                            exception.type = std::any::type_name_of_val(&e),
+                            "job notification listener error"
+                        );
                         tokio::time::sleep(Duration::from_secs(1)).await;
                     }
                 }

--- a/src/poller.rs
+++ b/src/poller.rs
@@ -153,7 +153,12 @@ impl JobPoller {
                 }
                 Err(e) => {
                     failures += 1;
-                    tracing::error!(error = %e, failures, "main loop error");
+                    tracing::error!(
+                        exception.message = %e,
+                        exception.type = std::any::type_name_of_val(&e),
+                        failures,
+                        "main loop error"
+                    );
                     Duration::from_millis(50 << failures)
                 }
             };
@@ -310,7 +315,12 @@ impl JobPoller {
                             }
                             Err(e) => {
                                 failures += 1;
-                                tracing::error!(instance_id = %instance_id, error = %e, "keep alive error");
+                                tracing::error!(
+                                    instance_id = %instance_id,
+                                    exception.message = %e,
+                                    exception.type = std::any::type_name_of_val(&e),
+                                    "keep alive error"
+                                );
                                 Duration::from_millis(50 << failures)
                             }
                         }
@@ -388,7 +398,11 @@ impl JobPoller {
                                     .record("max_pending_duration_secs", max_pending_secs);
                             }
                             Err(e) => {
-                                tracing::error!(error = %e, "failed to check stale pending jobs");
+                                tracing::error!(
+                                    exception.message = %e,
+                                    exception.type = std::any::type_name_of_val(&e),
+                                    "failed to check stale pending jobs"
+                                );
                             }
                         }
                     }
@@ -445,7 +459,13 @@ impl JobPoller {
             .execute_job(polled_job, shutdown_rx)
             .await
             {
-                tracing::error!(job_id = %id, attempt, error = %e, "job dispatcher error");
+                tracing::error!(
+                    job_id = %id,
+                    attempt,
+                    exception.message = %e,
+                    exception.type = std::any::type_name_of_val(&e),
+                    "job dispatcher error"
+                );
             }
         });
 


### PR DESCRIPTION
## Summary

- The `tracing::error!(error = %e, ...)` pattern at 5 callsites was silently dropping the sqlx/error display string in Honeycomb
- Honeycomb auto-derives a boolean `error` column from OTel span status; the string field named `error` collided with that boolean column on first write and was discarded
- Honeycomb triggers that broke down by `exception.message` (e.g. the lana-bank pod-error alert) consequently showed no error text — operators had to crawl pod logs to find the actual cause

## What this changes

All 5 error-level callsites now use the OTel-standard `exception.message` and `exception.type` field names instead of `error = %e`. This matches the established convention in `es-entity` (10+ files use the same pattern via `Span::current().record(...)`).

| file | line | log line |
|---|---|---|
| `notification_router.rs` | 109 | `job notification listener error` |
| `poller.rs` | 156 | `main loop error` |
| `poller.rs` | 313 | `keep alive error` |
| `poller.rs` | 391 | `failed to check stale pending jobs` |
| `poller.rs` | 448 | `job dispatcher error` |

`exception.type` is derived dynamically via `std::any::type_name_of_val(&e)` rather than hardcoded, so it stays correct if the error type is refactored.

WARN-level callsites are left unchanged in this PR — they have the same collision but lower visibility; happy to add them in a follow-up if desired.

## Why span events, not span attributes?

`es-entity` records exception fields on the **parent span** via `Span::current().record(...)`. That approach requires declaring `exception.message = tracing::field::Empty` etc. in each span's `instrument` macro / `info_span!` declaration.

The existing Honeycomb trigger filters on `level = ERROR`, which only matches event rows (spans don't have a `level` column). Putting the fields on the event (via the macro) means the existing trigger starts working without any Honeycomb-side change. A follow-up could mirror es-entity's pattern on the spans for completeness.

## Test plan

- [x] `cargo check` passes
- [x] `cargo clippy --no-deps` clean
- [ ] After merge + release + deploy, confirm in Honeycomb that the `volcano-qa-lana-bank` trigger now populates `exception.message` with the actual sqlx error text (test will be: next `job.check_stale_pending_jobs` ERROR event should show a non-empty `exception.message`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logging-only field renames on error paths; no job execution, auth, or data semantics change.
> 
> **Overview**
> **Error logs** in `notification_router.rs` and `poller.rs` no longer attach failures as `error = %e`. Five `tracing::error!` callsites now emit OpenTelemetry-style **`exception.message`** and **`exception.type`** (via `std::any::type_name_of_val(&e)`), so Honeycomb can store the real error text instead of losing it to a boolean `error` column collision.
> 
> Affected messages: job notification listener, poller main loop, keep-alive, stale pending check, and job dispatcher errors. **WARN** logs still use `error = %e`; unchanged in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dbb2f295af4d9487bcd2eb5ff7419a854c6d9799. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->