### PR TITLE
feat(entity): expose owned JobType constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,12 +126,21 @@ cleanup_spawner.spawn_unique(JobId::new(), CleanupConfig::default()).await?;
 ### Parameterized Job Types
 
 For cases where the job type is configured at runtime,
-store the job type in your initializer:
+create it with `JobType::from_owned` and store it in your initializer:
 
 ```rust
 struct TenantJobInitializer {
     job_type: JobType,
     tenant_id: String,
+}
+
+impl TenantJobInitializer {
+    fn new(tenant_id: String) -> Self {
+        Self {
+            job_type: JobType::from_owned(format!("tenant.{tenant_id}.sync")),
+            tenant_id,
+        }
+    }
 }
 
 impl JobInitializer for TenantJobInitializer {

--- a/src/entity.rs
+++ b/src/entity.rs
@@ -20,7 +20,8 @@ use crate::{
 #[serde(transparent)]
 /// Identifier describing a job type or class of work.
 ///
-/// Use `JobType::new` for static name registration.
+/// Use `JobType::new` for static name registration and
+/// `JobType::from_owned` for names derived from runtime configuration.
 ///
 /// # Examples
 ///
@@ -39,8 +40,11 @@ impl JobType {
         &self.0
     }
 
-    #[cfg(test)]
-    pub(crate) fn from_owned(job_type: String) -> Self {
+    /// Creates a job type from an owned string.
+    ///
+    /// Use this when the job type is derived from runtime configuration rather
+    /// than a compile-time literal.
+    pub fn from_owned(job_type: String) -> Self {
         JobType(Cow::Owned(job_type))
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -153,12 +153,22 @@
 //! ## Parameterized Job Types
 //!
 //! For cases where the job type is configured at runtime (e.g., multi-tenant inboxes),
-//! store the job type in your initializer and return it from the instance method:
+//! create it with `JobType::from_owned`, store it in your initializer, and return it
+//! from the instance method:
 //!
 //! ```ignore
 //! struct TenantJobInitializer {
 //!     job_type: JobType,
 //!     tenant_id: String,
+//! }
+//!
+//! impl TenantJobInitializer {
+//!     fn new(tenant_id: String) -> Self {
+//!         Self {
+//!             job_type: JobType::from_owned(format!("tenant.{tenant_id}.sync")),
+//!             tenant_id,
+//!         }
+//!     }
 //! }
 //!
 //! impl JobInitializer for TenantJobInitializer {


### PR DESCRIPTION
## Summary

- Expose `JobType::from_owned(String)` for runtime-configured job names.
- Document the owned constructor in the README and crate-level docs.

## Why

Downstream crates need product/tenant-scoped job types without leaking runtime strings to satisfy `JobType::new(&'static str)`. This is needed by `GaloyMoney/lana-bank#6220`.

## Tests

- `nix develop -c cargo fmt --check`
- `nix develop -c env SQLX_OFFLINE=true cargo check --workspace --all-targets`
- `nix develop -c env SQLX_OFFLINE=true cargo test --doc --workspace`

Note: plain `cargo check` without `SQLX_OFFLINE=true` tries to connect to Postgres for sqlx query validation and failed locally because no database was running.
