### PR TITLE
feat(entity): expose JobType::from_owned for runtime-constructed names

### DIFF
--- a/src/entity.rs
+++ b/src/entity.rs
@@ -20,7 +20,12 @@ use crate::{
 #[serde(transparent)]
 /// Identifier describing a job type or class of work.
 ///
-/// Use `JobType::new` for static name registration.
+/// Use `JobType::new` for compile-time-known names (the common case). Use
+/// `JobType::from_owned` when the name is only known at runtime — e.g. a
+/// per-instance discriminator from boot-time config in a multi-instance
+/// module. Runtime-constructed names retain the same uniqueness and
+/// registration semantics as static ones; the runner's flat global namespace
+/// does not distinguish between them.
 ///
 /// # Examples
 ///
@@ -28,6 +33,8 @@ use crate::{
 /// use job::JobType;
 ///
 /// const CLEANUP_JOB: JobType = JobType::new("cleanup-job");
+///
+/// let scoped = JobType::from_owned(format!("cleanup-job.{}", "tenant-a"));
 /// ```
 pub struct JobType(Cow<'static, str>);
 impl JobType {
@@ -39,8 +46,7 @@ impl JobType {
         &self.0
     }
 
-    #[cfg(test)]
-    pub(crate) fn from_owned(job_type: String) -> Self {
+    pub fn from_owned(job_type: String) -> Self {
         JobType(Cow::Owned(job_type))
     }
 }


### PR DESCRIPTION
## Summary

`JobType` was deliberately designed around the assumption that every name in the running system is a compile-time-known constant: `pub const fn new(&'static str)` is the only public constructor, and `from_owned(String)` exists but is gated `#[cfg(test)] pub(crate)`. That assumption held while every module registering jobs was a singleton.

Multi-instance modules break it. Their JobTypes need a per-instance discriminator (e.g. a product/tenant id from boot-time config) that the compiler can't see, so downstream callers fall back to `Box::leak` to fake a `&'static str`. The data model already supports the relaxation — the inner `Cow<'static, str>` accepts `Cow::Owned` — only the public surface still encodes the stricter assumption. This PR promotes `from_owned` to `pub` so runtime-constructed names are sanctioned rather than smuggled in.

### Tradeoffs

- **Dispatch-path allocation.** Owned variants allocate once at construction (boot/registration), not on dispatch. The "zero allocation anywhere" property weakens to "zero allocation on dispatch."
- **Grep-checkable uniqueness.** Static `pub const … = JobType::new("literal")` declarations are visible to review; runtime names aren't. Collisions still fail at registration via the existing `HashMap<JobType, _>` check, and the docstring steers callers toward `new` for the common case.
- **Rejected: leave it gated, document `Box::leak`.** Normalizes a workaround that misrepresents the contract, and the cost compounds with each module that goes multi-instance.
- **Rejected: a dedicated `from_instance(&'static str, &impl Display)` helper.** Premature — minimal change is visibility; an interning helper can land later if a pattern emerges.

### Originating discussion

Layer C in https://github.com/GaloyMoney/lana-bank/pull/6220#issuecomment-4570441826.

## Test plan

- [ ] `cargo check --all-features` clean
- [ ] `cargo clippy --all-features --lib --tests -- -D warnings` clean
- [ ] Existing `repo.rs` tests that use `from_owned` still pass
- [ ] Downstream `lana-bank` can drop the `Box::leak` workaround once released

🤖 Generated with [Claude Code](https://claude.com/claude-code)