### PR TITLE
fix: downgrade shutdown reschedule log severity

### DIFF
--- a/src/poller.rs
+++ b/src/poller.rs
@@ -854,7 +854,7 @@ async fn kill_remaining_jobs(
     for (job_id, mut job) in entities {
         let attempt_index = attempt_map[&job_id];
 
-        tracing::error!(
+        tracing::warn!(
             job_id = %job_id,
             job_type = %job.job_type,
             attempt = attempt_index,


### PR DESCRIPTION
## Summary

Downgrade the shutdown cleanup reschedule log from `error!` to `warn!`.

## Investigation

ZenDuty incidents fired in both staging and volcano-qa from Honeycomb LANA error alerts. Both alerts came from the same shutdown cleanup message:

`Job still running after shutdown timeout, forcing reschedule`

The alert fired because this message was emitted once per rescheduled job at ERROR level. In the observed incidents, each environment emitted 37 of these events.

We inspected the Honeycomb trace for staging, including trace `0aff61c2ffbb9b45f56515a684886a7b`.

At first glance, the trace made `job_repo.find_all` look suspicious, but that call succeeded. It returned the 37 job IDs with `status_code = 0`. The downstream `job_repo.update` spans also succeeded. The ERRORs were the per-job `tracing::error!` span events emitted after `find_all`, while the job crate was intentionally rescheduling running jobs during shutdown cleanup.

We also checked frequency over the queried 30 day window:

- staging: 1 cleanup occurrence, 37 jobs rescheduled
- volcano-qa: 1 cleanup occurrence, 37 jobs rescheduled

So this appears to be low-frequency shutdown/restart cleanup behavior, but noisy enough to page because each rescheduled job currently emits an ERROR event.

## Rationale

`kill_remaining_jobs` is an intentional recovery path during shutdown. It handles jobs still marked `running` for the shutting-down poller instance by:

- resetting the execution to `pending`
- clearing `poller_instance_id`
- recording `ExecutionAborted { reason: "killed job" }`
- recording `ExecutionScheduled { attempt, scheduled_at }`

This preserves the work and makes the job eligible to be picked up again by a poller. That is useful operational signal, but it is not itself a job-system failure.

Real failures in this path are still preserved: DB/repo operations continue to use `?`, so failures from the cleanup update, `find_all`, repo updates, or commit still propagate as actual errors.

## Via ZenDuty Alerts
- [Staging](https://ui.honeycomb.io/galoymoney/environments/staging/datasets/galoy-staging-main-lana-bank/result/u1CdkbaMDyu?utm_content=view_graph&utm_medium=Trigger&utm_source=webhook)
- [QA](https://ui.honeycomb.io/galoymoney/environments/volcano-qa/datasets/volcano-qa-main-lana-bank/result/z9d2zQP7vCT?utm_content=view_graph&utm_medium=Trigger&utm_source=webhook)

