### PR TITLE
fix(poller): downgrade shutdown reschedule log from ERROR to WARN

### DIFF
--- a/src/poller.rs
+++ b/src/poller.rs
@@ -854,7 +854,7 @@ async fn kill_remaining_jobs(
     for (job_id, mut job) in entities {
         let attempt_index = attempt_map[&job_id];
 
-        tracing::error!(
+        tracing::warn!(
             job_id = %job_id,
             job_type = %job.job_type,
             attempt = attempt_index,


### PR DESCRIPTION
## Summary

`kill_remaining_jobs` runs in the normal graceful-shutdown path: it marks in-flight jobs as `pending` so the next pod picks them up. The work is deferred, not lost. ERROR-level logging here misclassifies designed behavior as an operational failure — and the sibling shutdown-flow logs at `poller.rs:802` and `:809` are already WARN, so line 857 is the anomaly within this same function.

Downstream impact is concrete: at GaloyMoney, the `volcano-qa-main-lana-errors` Honeycomb trigger filters on `error=true AND level=ERROR` with threshold 0, so every pod-restart burst of 25–40 of these events fires Zenduty. That's 10 false pages in 6 weeks (4 in the last 24h alone) — currently the largest single source of on-call alert noise. Following the precedent of [cala#712](https://github.com/GaloyMoney/cala/pull/712), which downgraded the same class of false-ERROR noise in cala-ledger on the principle that a library shouldn't decide which of its errors are operational emergencies — the application layer should.

Other `tracing::error!` calls in `poller.rs` (lost job, send-ack failure) are genuine operational errors and are not touched.

## Test plan

- [ ] After lana-bank picks up the next published `job` version (\`0.6.26\`), confirm the next volcano-qa deploy produces zero pages from \`Job still running after shutdown timeout, forcing reschedule\` while the event still appears in Honeycomb at WARN (telemetry preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single observability-level change with no behavior, API, or job-handling logic modified.
> 
> **Overview**
> Downgrades the **"Job still running after shutdown timeout, forcing reschedule"** log in `kill_remaining_jobs` from **ERROR** to **WARN**.
> 
> That path is part of normal graceful shutdown: jobs still running after the timeout are aborted and rescheduled for another poller, not lost. Logging it as ERROR was inconsistent with other shutdown messages in the same flow (already WARN) and was tripping `level=ERROR` on-call alerts on every deploy/restart while telemetry stays visible at WARN.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 395e102696f83279d6ff5ceb53cc1b9f480e230f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->