### PR TITLE
test: drua rollout reactor ownership gate (no marker)

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -16,7 +16,7 @@ pub struct JobPollerConfig {
     pub job_lost_interval: Duration,
     #[serde(default = "default_max_jobs_per_process")]
     /// Maximum number of concurrent jobs this process will execute.
-    pub max_jobs_per_process: usize,
+        pub max_jobs_per_process: usize,
     #[serde(default = "default_min_jobs_per_process")]
     /// Minimum number of concurrent jobs to keep running before the poller sleeps.
     pub min_jobs_per_process: usize,


### PR DESCRIPTION
Synthetic test PR validating the ownership gate of the drua rollout CI reactors (drua-library#40). Same deliberate fmt violation as #118 but **without** the rollout marker — the reactors must leave this PR completely untouched (no fix commits, no comments, no draft flip). This PR will be closed and its branch deleted after the test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)