### PR TITLE
fix(poller): ref-count live jobs so a self-reclaim redispatch can't drop a live heartbeat

### DIFF
--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -25,6 +25,7 @@ pub(crate) struct JobDispatcher {
     runner: Option<Box<dyn JobRunner>>,
     tracker: Arc<JobTracker>,
     rescheduled: bool,
+    dispatched: bool,
     id: JobId,
     instance_id: uuid::Uuid,
     clock: ClockHandle,
@@ -45,6 +46,7 @@ impl JobDispatcher {
             runner: Some(runner),
             tracker,
             rescheduled: false,
+            dispatched: false,
             id,
             instance_id,
             clock,
@@ -93,6 +95,7 @@ impl JobDispatcher {
             self.clock.clone(),
             Arc::clone(&self.repo),
         );
+        self.dispatched = true;
         self.tracker.dispatch_job(self.id);
         match Self::dispatch_job(self.runner.take().expect("runner"), current_job).await {
             Err(e) => {
@@ -363,6 +366,12 @@ impl JobDispatcher {
 
 impl Drop for JobDispatcher {
     fn drop(&mut self) {
-        self.tracker.job_completed(self.id, self.rescheduled)
+        // Only balance the counter/registry if we actually registered. If
+        // `execute_job` errored before `dispatch_job` ran, there was no
+        // `Started`; emitting `Finished` here would drop another runner's live
+        // id and underflow the running-jobs counter.
+        if self.dispatched {
+            self.tracker.job_completed(self.id, self.rescheduled);
+        }
     }
 }

--- a/src/poller.rs
+++ b/src/poller.rs
@@ -5,7 +5,6 @@ use sqlx::postgres::{PgPool, types::PgInterval};
 use tracing::{Instrument, Span, instrument};
 
 use std::{
-    collections::HashSet,
     sync::{
         Arc,
         atomic::{AtomicBool, Ordering},
@@ -22,7 +21,7 @@ use super::{
     handle::OwnedTaskHandle,
     registry::JobRegistry,
     repo::JobRepo,
-    tracker::{JobTracker, LiveJobEvent},
+    tracker::{JobTracker, LiveJobEvent, LiveJobs},
 };
 
 /// Helper macro to spawn tasks with optional names based on the tokio-task-names feature
@@ -295,20 +294,17 @@ impl JobPoller {
         OwnedTaskHandle::new(spawn_named_task!(
             "job-poller-keep-alive-handler",
             async move {
-                // Jobs with a live runner future; the heartbeat is scoped to these
-                // so an orphaned `running` row stops being refreshed and goes stale.
-                let mut live_jobs: HashSet<JobId> = HashSet::new();
+                // Ref-counted set of jobs with a live runner future on this
+                // instance; the heartbeat is scoped to these ids, so an orphaned
+                // `running` row (no live future) stops being refreshed and goes
+                // stale. Note `poll_jobs` already seeds a fresh `alive_at` when it
+                // marks a row `running`, so a just-dispatched job is covered from
+                // the moment it exists — the keep-alive only continues that.
+                let mut live_jobs = LiveJobs::default();
                 let mut failures = 0;
                 loop {
                     while let Ok(event) = live_events_rx.try_recv() {
-                        match event {
-                            LiveJobEvent::Started(id) => {
-                                live_jobs.insert(id);
-                            }
-                            LiveJobEvent::Finished(id) => {
-                                live_jobs.remove(&id);
-                            }
-                        }
+                        live_jobs.apply(event);
                     }
 
                     // alive_at is a wall-clock liveness heartbeat (see lost-handler).
@@ -327,8 +323,7 @@ impl JobPoller {
                             failures = 0;
                             return job_lost_interval / 4;
                         }
-                        let live_ids: Vec<uuid::Uuid> =
-                            live_jobs.iter().map(|id| uuid::Uuid::from(*id)).collect();
+                        let live_ids = live_jobs.ids();
                         match sqlx::query!(
                             r#"
                         UPDATE job_executions

--- a/src/tracker.rs
+++ b/src/tracker.rs
@@ -1,5 +1,6 @@
 use tokio::sync::{Notify, mpsc};
 
+use std::collections::HashMap;
 use std::sync::{
     Mutex,
     atomic::{AtomicUsize, Ordering},
@@ -11,6 +12,54 @@ use super::JobId;
 pub(crate) enum LiveJobEvent {
     Started(JobId),
     Finished(JobId),
+}
+
+/// Ref-counted set of jobs with a live runner future on this instance, owned by
+/// the keep-alive handler.
+///
+/// A single job id can have more than one live runner at once on the same
+/// instance: a self-reclaim (the lost-handler reclaiming a stale-but-still-live
+/// row) lets the poller re-dispatch a job while its previous future is still
+/// running. A plain set would drop the id on the *first* `Finished`, leaving the
+/// other still-live runner un-heartbeated. Counting keeps the id alive until the
+/// last runner finishes.
+#[derive(Default)]
+pub(crate) struct LiveJobs {
+    counts: HashMap<JobId, usize>,
+}
+
+impl LiveJobs {
+    pub fn apply(&mut self, event: LiveJobEvent) {
+        match event {
+            LiveJobEvent::Started(id) => {
+                *self.counts.entry(id).or_insert(0) += 1;
+            }
+            LiveJobEvent::Finished(id) => {
+                // `get_mut` guards an unmatched `Finished` (a runner that errored
+                // before it registered): decrement nothing rather than evict a
+                // different runner's still-live id.
+                if let Some(n) = self.counts.get_mut(&id) {
+                    *n -= 1;
+                    if *n == 0 {
+                        self.counts.remove(&id);
+                    }
+                }
+            }
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.counts.is_empty()
+    }
+
+    pub fn len(&self) -> usize {
+        self.counts.len()
+    }
+
+    /// The distinct live job ids as raw UUIDs, for binding to `id = ANY($n)`.
+    pub fn ids(&self) -> Vec<uuid::Uuid> {
+        self.counts.keys().map(|id| uuid::Uuid::from(*id)).collect()
+    }
 }
 
 pub(crate) struct JobTracker {
@@ -73,5 +122,38 @@ impl JobTracker {
         if rescheduled || n_running_jobs == self.min_jobs {
             self.notify.notify_one();
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn keeps_id_until_last_runner_finishes() {
+        let id = JobId::new();
+        let mut live = LiveJobs::default();
+
+        // Two concurrent runners for the same id (self-reclaim re-dispatch).
+        live.apply(LiveJobEvent::Started(id));
+        live.apply(LiveJobEvent::Started(id));
+        assert_eq!(live.len(), 1);
+
+        // First runner finishes: the id must stay live for the second.
+        live.apply(LiveJobEvent::Finished(id));
+        assert!(!live.is_empty(), "id dropped while a runner is still live");
+        assert_eq!(live.ids().len(), 1);
+
+        // Second runner finishes: only now is the id removed.
+        live.apply(LiveJobEvent::Finished(id));
+        assert!(live.is_empty());
+    }
+
+    #[test]
+    fn ignores_unmatched_finished() {
+        let id = JobId::new();
+        let mut live = LiveJobs::default();
+        live.apply(LiveJobEvent::Finished(id));
+        assert!(live.is_empty());
     }
 }


### PR DESCRIPTION
Follow-up to #123, addressing the two Cursor Bugbot findings on the heartbeat path introduced there.

## Finding 2 (real) — `Finished` drops a shared live job

The keep-alive handler tracked live jobs in a `HashSet<JobId>`. A single job id can have **two concurrent runners on the same instance**: a self-reclaim (#123's Fix B — the lost-handler reclaiming a stale-but-still-live `running` row, e.g. after a DB outage longer than `job_lost_interval`, then losing the recovery race to the keep-alive) lets the poller re-dispatch a job while its **previous future is still running**. With a set:

- Runner A `Started` → `{J}`; Runner B `Started` → `{J}`; Runner A `Finished` → **`{}`** — drops `J` even though Runner B is still live → B's row stops being heartbeated → goes stale → reclaimed again.

### Fix
- Replace the set with a **ref-counted `LiveJobs`** map: `Started` increments, `Finished` decrements and removes at zero, so an id stays heartbeated until the **last** runner finishes. (New unit tests cover the concurrent-runner and unmatched-`Finished` cases.)
- **Pairing guard:** gate `JobDispatcher::Drop`'s `job_completed` on a `dispatched` flag. If `execute_job` errors before `dispatch_job` runs (e.g. its `find_by_id` fails), there was no `Started`; emitting an unmatched `Finished` would corrupt the ref-count **and** — a pre-existing latent bug — underflow the running-jobs `AtomicUsize` toward a poller wedge. The flag makes `Started`/`Finished` and the counter provably paired.

## Finding 1 (not a bug) — "running rows lack early heartbeat"

Dismissed with reasoning. `poll_jobs` sets `alive_at = wall_now` in the **same statement** that flips a row to `running` (`poller.rs`), so every running row has a fresh, wall-clock heartbeat with a full `job_lost_interval` of runway from the instant it exists. `LiveJobEvent::Started` fires ~ms later and the keep-alive *continues* the heartbeat within `job_lost_interval/4` (≪ the staleness threshold). An unregistered row trends toward *reclaim*, not toward an eternal zombie, so the window can neither zombie nor (given ms-scale dispatch vs. a 300s threshold) spuriously reclaim. Added a clarifying comment; no functional change.

## Out of scope (noted)

The deeper same-instance double-dispatch property — Runner A's terminal write can touch Runner B's row since both share `poller_instance_id` — is tolerated by the existing at-least-once/idempotency contract and belongs with the deferred durable-terminal-write hardening (Fix C).

## Verification
- `nextest`: **60/60** (incl. 2 new `LiveJobs` unit tests)
- doc tests pass
- `nix flake check` (fmt, clippy `-D warnings`, audit, deny): **all checks passed**
- No `.sqlx` change (no query touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes job liveness heartbeats and running-job accounting on the poller hot path; behavior is narrow and covered by new tests, but mistakes could cause spurious lost-job reclaims or poller wedging.
> 
> **Overview**
> Fixes **keep-alive tracking** when the same job id can have **two concurrent runners** on one poller instance (e.g. lost-handler self-reclaim while the original future is still running).
> 
> The keep-alive handler now uses ref-counted **`LiveJobs`** instead of a `HashSet`: each `Started` increments and each `Finished` decrements, so a job id stays heartbeated until the **last** runner finishes. Unmatched `Finished` events are ignored so early failures do not corrupt another runner’s entry.
> 
> **`JobDispatcher`** sets a **`dispatched`** flag when `dispatch_job` runs and only calls **`job_completed`** from **`Drop`** when that flag is set, pairing `Started`/`Finished` and avoiding running-job counter underflow when `execute_job` fails before registration.
> 
> Adds unit tests for concurrent runners and unmatched `Finished`; poller comments clarify that `poll_jobs` already seeds `alive_at` at dispatch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b7cdce5bfa8e19b515f34b2498cca4f17274772. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->