### PR TITLE
fix(notification_router): make completion-waiter sweep unstarvable so await_completions can't wedge

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -28,6 +28,13 @@ pub struct JobPollerConfig {
     /// Capacity of the broadcast channel used to propagate terminal-job notifications.
     pub terminal_channel_size: usize,
     #[serde_as(as = "serde_with::DurationSeconds<u64>")]
+    #[serde(default = "default_sweep_interval")]
+    /// How often the waiter-manager reconciles registered completion-waiters
+    /// against the database. This is the backstop that resolves waiters whose
+    /// terminal notification was dropped (e.g. broadcast overflow), so it must
+    /// run on a predictable cadence.
+    pub sweep_interval: Duration,
+    #[serde_as(as = "serde_with::DurationSeconds<u64>")]
     #[serde(default = "default_pending_jobs_check_interval")]
     /// How often to check for pending jobs that are past their scheduled execution time.
     pub pending_jobs_check_interval: Duration,
@@ -41,6 +48,7 @@ impl Default for JobPollerConfig {
             min_jobs_per_process: default_min_jobs_per_process(),
             shutdown_timeout: default_shutdown_timeout(),
             terminal_channel_size: default_terminal_channel_size(),
+            sweep_interval: default_sweep_interval(),
             pending_jobs_check_interval: default_pending_jobs_check_interval(),
         }
     }
@@ -173,6 +181,10 @@ fn default_shutdown_timeout() -> Duration {
 
 fn default_terminal_channel_size() -> usize {
     1024
+}
+
+fn default_sweep_interval() -> Duration {
+    Duration::from_secs(30)
 }
 
 fn default_pending_jobs_check_interval() -> Duration {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -288,6 +288,7 @@ impl Jobs {
             &pool,
             Arc::clone(&repo),
             config.poller_config.terminal_channel_size,
+            config.poller_config.sweep_interval,
         ));
         let clock = config.clock.clone();
         Ok(Self {

--- a/src/notification_router.rs
+++ b/src/notification_router.rs
@@ -1,6 +1,6 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, OnceLock};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use crate::JobId;
 use crate::entity::JobType;
@@ -10,7 +10,7 @@ use crate::repo::JobRepo;
 use crate::tracker::JobTracker;
 use sqlx::postgres::{PgListener, PgPool};
 use tokio::sync::{broadcast, mpsc, oneshot};
-use tracing::instrument;
+use tracing::{Span, instrument};
 
 /// Notification types from the unified `job_events` channel.
 #[derive(Debug, serde::Deserialize)]
@@ -22,21 +22,47 @@ enum JobNotification {
 
 type WaiterRegistration = (JobId, oneshot::Sender<JobTerminalState>);
 
+/// The set of oneshot senders waiting on a single job, plus when the first of
+/// them registered. `registered_at` powers the oldest-waiter-age gauge so a
+/// stalled wait is observable instead of silent.
+struct Waiters {
+    senders: Vec<oneshot::Sender<JobTerminalState>>,
+    registered_at: Instant,
+}
+
+impl Waiters {
+    fn new() -> Self {
+        Self {
+            senders: Vec::new(),
+            registered_at: Instant::now(),
+        }
+    }
+}
+
+type WaiterMap = HashMap<JobId, Waiters>;
+
 pub(crate) struct JobNotificationRouter {
     pool: PgPool,
     repo: Arc<JobRepo>,
     terminal_tx: broadcast::Sender<JobId>,
     register_tx: OnceLock<mpsc::UnboundedSender<WaiterRegistration>>,
+    sweep_interval: Duration,
 }
 
 impl JobNotificationRouter {
-    pub fn new(pool: &PgPool, repo: Arc<JobRepo>, buffer_size: usize) -> Self {
+    pub fn new(
+        pool: &PgPool,
+        repo: Arc<JobRepo>,
+        buffer_size: usize,
+        sweep_interval: Duration,
+    ) -> Self {
         let (terminal_tx, _) = broadcast::channel(buffer_size.max(1));
         Self {
             pool: pool.clone(),
             repo,
             terminal_tx,
             register_tx: OnceLock::new(),
+            sweep_interval,
         }
     }
 
@@ -68,6 +94,7 @@ impl JobNotificationRouter {
             self.terminal_tx.subscribe(),
             self.pool.clone(),
             self.repo.clone(),
+            self.sweep_interval,
         );
         Ok((listener_handle, waiter_handle))
     }
@@ -125,47 +152,42 @@ impl JobNotificationRouter {
         mut terminal_rx: broadcast::Receiver<JobId>,
         pool: PgPool,
         repo: Arc<JobRepo>,
+        sweep_interval: Duration,
     ) -> OwnedTaskHandle {
         let handle = tokio::spawn(async move {
-            let mut waiters: HashMap<JobId, Vec<oneshot::Sender<JobTerminalState>>> =
-                HashMap::new();
-            let mut sweep = tokio::time::interval(SWEEP_INTERVAL);
+            let mut waiters: WaiterMap = HashMap::new();
+            let mut sweep = tokio::time::interval(sweep_interval);
+            // Missed ticks are redundant (the sweep is idempotent), so don't let
+            // a brief stall queue a burst of catch-up sweeps.
+            sweep.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
             loop {
                 tokio::select! {
                     biased;
 
-                    Some((job_id, tx)) = register_rx.recv() => {
-                        // Immediate DB check: no execution row means the job is terminal
-                        match has_execution_row(&pool, job_id).await {
-                            Ok(false) => {
-                                // No execution row → job is terminal, but the caller
-                                // needs to know *how* it ended (Completed vs Errored),
-                                // so we load the entity's event history.
-                                // On transient DB failure the waiter is parked for the
-                                // sweep to retry.
-                                match load_terminal_state(&repo, job_id).await {
-                                    Some(state) => {
-                                        let _ = tx.send(state);
-                                        send_to_waiters(&mut waiters, job_id, state);
-                                    }
-                                    None => {
-                                        waiters.entry(job_id).or_default().push(tx);
-                                    }
-                                }
-                            }
-                            Ok(true) => {
-                                waiters.entry(job_id).or_default().push(tx);
-                            }
-                            Err(e) => {
-                                tracing::warn!(
-                                    error = %e,
-                                    "register_waiter: failed to check execution row"
-                                );
-                                // Register anyway — sweep will catch it
-                                waiters.entry(job_id).or_default().push(tx);
-                            }
+                    // The reconciliation sweep is polled FIRST so a sustained
+                    // terminal-notification firehose can never starve it. It is
+                    // the only backstop that resolves waiters whose single
+                    // terminal notification was dropped (broadcast overflow) and
+                    // is never redelivered; if it can be starved, those waiters
+                    // wedge until the process restarts. `tick()` is ready only
+                    // once per interval, so giving it priority only pre-empts the
+                    // register/terminal branches for one iteration per period.
+                    _ = sweep.tick() => {
+                        sweep_waiters(&mut waiters, &pool, &repo).await;
+                    }
+
+                    // Registration is polled before the terminal branch so a
+                    // waiter lands in the map before the terminal notification
+                    // for its job is processed (avoids a lost wakeup). All
+                    // immediately-available registrations are drained and checked
+                    // with a single query rather than one round-trip per waiter.
+                    Some(reg) = register_rx.recv() => {
+                        let mut batch = vec![reg];
+                        while let Ok(next) = register_rx.try_recv() {
+                            batch.push(next);
                         }
+                        register_waiters(&mut waiters, &pool, &repo, batch).await;
                     }
 
                     result = terminal_rx.recv() => {
@@ -204,10 +226,6 @@ impl JobNotificationRouter {
                             }
                         }
                     }
-
-                    _ = sweep.tick() => {
-                        sweep_waiters(&mut waiters, &pool, &repo).await;
-                    }
                 }
             }
         });
@@ -216,34 +234,98 @@ impl JobNotificationRouter {
     }
 }
 
-const SWEEP_INTERVAL: Duration = Duration::from_secs(30);
+/// Register a batch of completion-waiters.
+///
+/// Every registration is parked first (so a concurrent terminal notification can
+/// find it), then a single query determines which jobs are still running; any
+/// job with no execution row is already terminal and is resolved immediately in
+/// one batched entity load. This replaces the previous one-DB-round-trip-per-
+/// registration path, which both serialized large batches and monopolized the
+/// waiter-manager while completion notifications piled up and overflowed.
+async fn register_waiters(
+    waiters: &mut WaiterMap,
+    pool: &PgPool,
+    repo: &JobRepo,
+    batch: Vec<WaiterRegistration>,
+) {
+    let mut ids: Vec<JobId> = Vec::with_capacity(batch.len());
+    for (job_id, tx) in batch {
+        ids.push(job_id);
+        waiters
+            .entry(job_id)
+            .or_insert_with(Waiters::new)
+            .senders
+            .push(tx);
+    }
 
-/// Check whether a `job_executions` row exists for the given ID.
-async fn has_execution_row(pool: &PgPool, id: JobId) -> Result<bool, sqlx::Error> {
-    let row = sqlx::query!("SELECT id FROM job_executions WHERE id = $1", id as JobId,)
-        .fetch_optional(pool)
-        .await?;
-    Ok(row.is_some())
+    // Single batched query: the subset of IDs that still have execution rows
+    // (i.e. are still running). Any ID NOT returned is terminal.
+    let still_running: HashSet<JobId> = match sqlx::query_scalar!(
+        "SELECT id FROM job_executions WHERE id = ANY($1)",
+        &ids as &[JobId],
+    )
+    .fetch_all(pool)
+    .await
+    {
+        Ok(rows) => rows.into_iter().map(JobId::from).collect(),
+        Err(e) => {
+            tracing::warn!(
+                error = %e,
+                "register_waiters: failed to batch-check execution rows"
+            );
+            // Everyone stays parked — the sweep will retry.
+            return;
+        }
+    };
+
+    let terminal_ids: Vec<JobId> = ids
+        .into_iter()
+        .filter(|id| !still_running.contains(id))
+        .collect();
+
+    if !terminal_ids.is_empty() {
+        batch_load_and_notify(waiters, repo, terminal_ids).await;
+    }
 }
 
 /// Sweep all waiters: prune closed receivers and check for newly-terminal jobs.
 ///
 /// Uses a single batched query instead of N sequential queries to determine
 /// which waited-on jobs have reached terminal state.
-async fn sweep_waiters(
-    waiters: &mut HashMap<JobId, Vec<oneshot::Sender<JobTerminalState>>>,
-    pool: &PgPool,
-    repo: &JobRepo,
-) {
+///
+/// A waiter resolved here is one whose terminal notification never arrived
+/// (dropped on broadcast overflow, or a transient load failure at registration).
+/// A nonzero `n_resolved` therefore means notification delivery is lagging and
+/// the sweep is carrying completion delivery — the early warning that would have
+/// surfaced the 35 h wedge in minutes — so it is logged at `warn`.
+#[instrument(
+    name = "job.notification_router.sweep_waiters",
+    skip_all,
+    fields(n_waiters, oldest_waiter_age_secs, n_resolved)
+)]
+async fn sweep_waiters(waiters: &mut WaiterMap, pool: &PgPool, repo: &JobRepo) {
     // Prune dropped receivers
-    waiters.retain(|_, senders| {
-        senders.retain(|tx| !tx.is_closed());
-        !senders.is_empty()
+    waiters.retain(|_, w| {
+        w.senders.retain(|tx| !tx.is_closed());
+        !w.senders.is_empty()
     });
 
+    let span = Span::current();
     if waiters.is_empty() {
+        span.record("n_waiters", 0);
+        span.record("oldest_waiter_age_secs", 0u64);
+        span.record("n_resolved", 0);
         return;
     }
+
+    let n_waiters = waiters.len();
+    let oldest_age = waiters
+        .values()
+        .map(|w| w.registered_at.elapsed())
+        .max()
+        .unwrap_or_default();
+    span.record("n_waiters", n_waiters);
+    span.record("oldest_waiter_age_secs", oldest_age.as_secs());
 
     let ids: Vec<JobId> = waiters.keys().copied().collect();
 
@@ -264,10 +346,22 @@ async fn sweep_waiters(
     };
 
     // Notify waiters for jobs that no longer have an execution row
+    let mut n_resolved = 0usize;
     for id in ids {
-        if !still_running.contains(&id) {
-            load_and_notify(waiters, repo, id).await;
+        if !still_running.contains(&id) && load_and_notify(waiters, repo, id).await {
+            n_resolved += 1;
         }
+    }
+    span.record("n_resolved", n_resolved);
+
+    if n_resolved > 0 {
+        tracing::warn!(
+            n_resolved,
+            n_waiters,
+            oldest_waiter_age_secs = oldest_age.as_secs(),
+            "sweep resolved already-terminal waiters whose terminal notification \
+             was never delivered — notification delivery is lagging"
+        );
     }
 }
 
@@ -291,28 +385,25 @@ async fn load_terminal_state(repo: &JobRepo, job_id: JobId) -> Option<JobTermina
 
 /// Load the job entity and send the terminal state to all registered waiters.
 /// On failure, waiters remain registered so the sweep can retry.
-async fn load_and_notify(
-    waiters: &mut HashMap<JobId, Vec<oneshot::Sender<JobTerminalState>>>,
-    repo: &JobRepo,
-    job_id: JobId,
-) {
+///
+/// Returns `true` if the job was terminal and its waiters were notified.
+async fn load_and_notify(waiters: &mut WaiterMap, repo: &JobRepo, job_id: JobId) -> bool {
     if !waiters.contains_key(&job_id) {
-        return;
+        return false;
     }
 
     if let Some(state) = load_terminal_state(repo, job_id).await {
         send_to_waiters(waiters, job_id, state);
+        true
+    } else {
+        false
     }
 }
 
 /// Load multiple job entities in a single query and notify all registered waiters.
 /// Jobs that fail to load remain registered for the sweep to retry.
 #[instrument(name = "job.notification_router.batch_load_and_notify", skip_all)]
-async fn batch_load_and_notify(
-    waiters: &mut HashMap<JobId, Vec<oneshot::Sender<JobTerminalState>>>,
-    repo: &JobRepo,
-    ids: Vec<JobId>,
-) {
+async fn batch_load_and_notify(waiters: &mut WaiterMap, repo: &JobRepo, ids: Vec<JobId>) {
     // Deduplicate and keep only IDs with active waiters
     let unique_ids: Vec<JobId> = ids
         .into_iter()
@@ -350,13 +441,9 @@ async fn batch_load_and_notify(
 }
 
 /// Deliver a known terminal state to all waiters for a job.
-fn send_to_waiters(
-    waiters: &mut HashMap<JobId, Vec<oneshot::Sender<JobTerminalState>>>,
-    job_id: JobId,
-    state: JobTerminalState,
-) {
-    if let Some(senders) = waiters.remove(&job_id) {
-        for tx in senders {
+fn send_to_waiters(waiters: &mut WaiterMap, job_id: JobId, state: JobTerminalState) {
+    if let Some(w) = waiters.remove(&job_id) {
+        for tx in w.senders {
             let _ = tx.send(state);
         }
     }

--- a/tests/job.rs
+++ b/tests/job.rs
@@ -1598,6 +1598,66 @@ async fn test_await_completions_timeout() -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Regression test for the `await_completions` wedge: an orchestrator that waits
+/// on a burst of fast-completing jobs must not hang when their terminal
+/// notifications are dropped.
+///
+/// Preconditions are reproduced deterministically: a size-1 terminal broadcast
+/// buffer so a completion burst overflows it and those notifications are lost
+/// (they are never redelivered), leaving the periodic reconciliation sweep as
+/// the sole resolution path. Previously that sweep was the lowest-priority arm
+/// of a `biased` select and could be starved indefinitely by a terminal
+/// firehose, wedging `await_completions(None)` until the process restarted. With
+/// the sweep polled first, a bounded `sweep_interval` caps resolution regardless
+/// of load — so this must complete well within the timeout.
+#[tokio::test]
+async fn test_await_completions_resolves_when_notifications_dropped() -> anyhow::Result<()> {
+    use job::JobPollerConfig;
+
+    let pool = helpers::init_pool().await?;
+    let config = JobSvcConfig::builder()
+        .pool(pool)
+        .poller_config(JobPollerConfig {
+            // Tiny buffer: a completion burst overflows it and terminal
+            // notifications are dropped, forcing resolution through the sweep.
+            terminal_channel_size: 1,
+            // Short cadence so the (now unstarvable) backstop is fast to assert on.
+            sweep_interval: Duration::from_millis(250),
+            ..Default::default()
+        })
+        .build()
+        .expect("Failed to build JobsConfig");
+
+    let mut jobs = Jobs::init(config).await?;
+    let spawner = jobs.add_initializer(TestJobInitializer {
+        job_type: JobType::new("await-completions-dropped-notifications"),
+    });
+    jobs.start_poll().await?;
+
+    // A burst of fast jobs that all finish in a tight window.
+    let ids: Vec<JobId> = (0..40).map(|_| JobId::new()).collect();
+    for id in &ids {
+        spawner.spawn(*id, TestJobConfig { delay_ms: 10 }).await?;
+    }
+
+    // `None` = wait indefinitely. It must still resolve — via the sweep — despite
+    // the dropped notifications. The outer timeout is the wedge assertion.
+    let outcomes =
+        tokio::time::timeout(Duration::from_secs(20), jobs.await_completions(&ids, None))
+            .await
+            .expect("await_completions wedged: dropped notifications were never reconciled")?;
+
+    assert_eq!(outcomes.len(), ids.len());
+    assert!(
+        outcomes
+            .iter()
+            .all(|o| o.state() == JobTerminalState::Completed)
+    );
+
+    jobs.shutdown().await?;
+    Ok(())
+}
+
 #[tokio::test]
 async fn test_job_completion_results_trait() -> anyhow::Result<()> {
     let pool = helpers::init_pool().await?;


### PR DESCRIPTION
## Summary
Fixes the `await_completions` wedge: an orchestrator waiting on a batch of fast jobs via `await_completions(&ids, None)` could hang for ~35h even though every job reached terminal state within ~65s, resolving only on process restart. (See `job-dev/await-completions-wedge.md`.)

## Root cause
The waiter-manager (`notification_router.rs`) runs one `tokio::select! { biased; register; terminal; sweep }`. The 30s reconciliation **sweep was the lowest-priority arm** and is the only backstop that resolves a waiter whose terminal notification was dropped. Terminal notifications fire exactly once, atomically on the execution-row `DELETE` (PG trigger), into a bounded broadcast (default 1024). Under a completion burst the broadcast overflows and those notifications are lost forever; parked waiters then depend solely on the sweep — which a sustained terminal firehose from the rest of the system can **starve indefinitely** under `biased`.

**Invariant broken:** a parked waiter for a terminal job resolves within one sweep interval.

Amplifier: registration did one DB round-trip **per waiter**, monopolizing the loop during the exact window the completion notifications arrived (guaranteeing the overflow) and adding O(N) serial queries per batch await.

## Fix (framework, contained to the waiter-manager)
- **Sweep polled first** in the `biased` select → the firehose can no longer starve it. `tick()` is ready only once per interval, so it pre-empts the other arms for at most one iteration per period. Register stays before terminal (preserves the register-before-terminal lost-wakeup guard). Wedge is now bounded by ~one `sweep_interval`.
- **Batched, non-blocking registration**: drain all pending registrations and check execution rows in a single query.
- **`sweep_interval` exposed** on `JobPollerConfig` (default 30s) — tunable + testable, no behavior change for existing users.
- **Observability**: sweep records `n_waiters`, `oldest_waiter_age_secs`, `n_resolved`, and `warn!`s when it has to rescue already-terminal waiters (delivery is lagging) — the early signal this incident lacked.
- **Regression test**: size-1 broadcast + 40-job burst forces dropped notifications and asserts `await_completions(None)` still resolves via the sweep (passes in ~0.15s).

## Alternatives considered
- Dedicated sweep timer task with `Arc<Mutex>` waiters — stronger isolation from handler latency, but adds locking and breaks single-owner; not worth it since handlers only await the DB (a slow DB would delay a dedicated task equally).
- Random (non-`biased`) fairness — only reduces starvation probabilistically; no hard bound.

## Compatibility with #123 / #124
Zero file overlap. #123 (merged) and #124 (open, `fix/keep-alive-live-jobs-refcount`) touch `poller.rs`/`tracker.rs`/`dispatcher.rs` (the `LiveJobs` keep-alive registry); this change is confined to `notification_router.rs` plus config wiring. Orthogonal — no conflict.

## Follow-up (separate repo)
Defense-in-depth mitigation for lana-bank: pass `Some(timeout)` to `await_completions` and map `JobError::TimedOut -> RescheduleNow`. Caps blast radius immediately for that caller; the framework fix here is the general fix.

## Verification
- `nix flake check` — all checks pass (fmt, `--all-features` clippy `--deny warnings`, audit, deny).
- `cargo nextest run --workspace` — 59/59 pass, including the new regression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core completion-waiter scheduling and batch-await behavior; a bug here can wedge orchestrators indefinitely, though the fix is localized to the notification router and adds tests.
> 
> **Overview**
> Fixes **`await_completions`** hanging indefinitely when terminal broadcast notifications are dropped (e.g. buffer overflow during a completion burst). Waiters then depend on a periodic DB reconciliation **sweep**; that sweep used to be the **lowest-priority** arm of a `biased` `select!` and could be starved by a steady stream of terminal events.
> 
> The sweep is now polled **first**, with **`MissedTickBehavior::Skip`** so catch-up ticks cannot pile up. Registration is **batched** (drain the channel, one `job_executions` query for all IDs) instead of one DB round-trip per waiter. **`sweep_interval`** is configurable on **`JobPollerConfig`** (default 30s) and passed into **`JobNotificationRouter`**.
> 
> Sweep runs record **`n_waiters`**, **`oldest_waiter_age_secs`**, and **`n_resolved`**, with a **`warn!`** when the sweep has to deliver completions that notifications missed. A regression test uses a size-1 terminal channel and 40 fast jobs to assert **`await_completions(None)`** still finishes within a bounded time.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit adb05114e6460624c710809cff0a693f7a44ef2a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->