### PR TITLE
chore: tune job_executions storage for update-heavy churn

### DIFF
--- a/migrations/20250904065521_job_setup.sql
+++ b/migrations/20250904065521_job_setup.sql
@@ -53,6 +53,20 @@ CREATE INDEX idx_job_executions_running_queue_id
   ON job_executions(queue_id)
   WHERE state = 'running' AND queue_id IS NOT NULL;
 
+-- job_executions is a small, extremely update-heavy table (state flips,
+-- heartbeat bumps, per-attempt reschedules). A lowered fillfactor leaves
+-- room in each page so non-indexed-column updates (execution_state_json,
+-- alive_at, poller_instance_id) can go HOT instead of appending a new
+-- row version elsewhere, and aggressive autovacuum settings keep dead
+-- tuples near zero — cheap at this table size, and it stops the poll
+-- query's cost from growing between default-schedule vacuums.
+ALTER TABLE job_executions SET (
+  fillfactor = 70,
+  autovacuum_vacuum_scale_factor = 0.01,
+  autovacuum_vacuum_threshold = 50,
+  autovacuum_analyze_scale_factor = 0.02
+);
+
 CREATE OR REPLACE FUNCTION notify_job_event() RETURNS TRIGGER AS $$
 BEGIN
   IF TG_OP = 'INSERT' THEN


### PR DESCRIPTION
## Motivation

`job_executions` is a small but extremely update-heavy table: state flips (`pending ↔ running`), `alive_at` heartbeat bumps, `execution_state_json` progress writes, and per-attempt reschedules. Observed on a 10 loans/s stress-test sandbox:

- ~2.5k dead tuples on ~1.4k live rows with autovacuum running every ~4 min on the default schedule
- the poll query's mean execution time climbing between vacuums (320ms → 374ms over 15 min)

## Change

Per-table storage parameters in the setup migration:

```sql
ALTER TABLE job_executions SET (
  fillfactor = 70,
  autovacuum_vacuum_scale_factor = 0.01,
  autovacuum_vacuum_threshold = 50,
  autovacuum_analyze_scale_factor = 0.02
);
```

- **`fillfactor = 70`** leaves per-page room so updates that touch no indexed column (`execution_state_json`, `alive_at`, `poller_instance_id`) can go **HOT** — no new page append, no index maintenance, less bloat per update.
- **Aggressive autovacuum** (scale factor 0.01, threshold 50) vacuums the table almost constantly; at this size a vacuum is sub-second and keeps dead tuples near zero instead of letting them accumulate to table scale between default-schedule runs.

## Notes

- Trade-off: fillfactor 70 costs ~30% more pages for a tiny table — negligible. If `job_executions` ever grows large, the autovacuum scale factor should be revisited (0.01 of a huge table is no longer "often").
- Complementary to the drop-`alive_at`-index PR: that removes churn at the source, this bounds the cost of the churn that remains. Either can land without the other.
- Migration edited in place per repo convention; downstream vendors (e.g. lana-bank `lana/app/migrations/20250904065521_job_setup.sql`) need the same edit when bumping the crate.
