### PR TITLE
perf(job): unthrottle autovacuum on job_executions

### DIFF
--- a/migrations/20250904065521_job_setup.sql
+++ b/migrations/20250904065521_job_setup.sql
@@ -56,11 +56,15 @@ CREATE INDEX idx_job_executions_running_queue_id
 -- row version elsewhere, and aggressive autovacuum settings keep dead
 -- tuples near zero — cheap at this table size, and it stops the poll
 -- query's cost from growing between default-schedule vacuums.
+-- cost_delay = 0 removes the vacuum throttle: at this table's churn
+-- rate the default 2ms delay reclaims dead tuples slower than they
+-- accumulate, and the poll query's cost grows with the backlog.
 ALTER TABLE job_executions SET (
   fillfactor = 70,
   autovacuum_vacuum_scale_factor = 0.01,
   autovacuum_vacuum_threshold = 50,
-  autovacuum_analyze_scale_factor = 0.02
+  autovacuum_analyze_scale_factor = 0.02,
+  autovacuum_vacuum_cost_delay = 0
 );
 
 CREATE OR REPLACE FUNCTION notify_job_event() RETURNS TRIGGER AS $$


### PR DESCRIPTION
## Why

During a 1h, 10-loans/s-target lana-bank stress-test soak (`sb-shard10bench` sandbox, 2026-07-29), `job_executions` accumulated **13,893 dead tuples against 114 live rows** despite the aggressive autovacuum triggers already in this migration (`scale_factor = 0.01`, `threshold = 50`). The poller's `WITH due AS (...)` query degraded from **~9 ms at startup to ~30 ms** and stayed there.

The trigger thresholds were firing — the bottleneck was the **default 2 ms `vacuum_cost_delay` throttle**: each autovacuum run reclaimed dead tuples slower than the workload created them.

## What

Adds `autovacuum_vacuum_cost_delay = 0` to the existing per-table settings. The table is tiny (~100 live rows), so unthrottled vacuum runs are cheap and keep dead tuples near zero, holding the poll query's cost flat.

Mirrors GaloyMoney/lana-bank#7675, which carries the same change in lana-bank's vendored copy of this migration (files verified identical).

## Evidence

- `pg_stat_user_tables`: `n_live_tup = 114`, `n_dead_tup = 13,893`
- `pg_stat_statements` (job poll, queryid `-7391300573923152793`): mean 9.2 ms (startup) → 30.1 ms (T+25min) → 27.5 ms (T+1h)