### PR TITLE
chore(dispatcher): reuse lifecycle operation for job reads

### DIFF
--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -254,7 +254,7 @@ impl JobDispatcher {
     )]
     async fn fail_job(&mut self, id: JobId, error: JobError, attempt: u32) -> Result<(), JobError> {
         let mut op = self.repo.begin_op_with_clock(&self.clock).await?;
-        let mut job = self.repo.find_by_id(id).await?;
+        let mut job = self.repo.find_by_id_in_op(&mut op, id).await?;
 
         let span = Span::current();
         let error_str = error.to_string();
@@ -326,7 +326,7 @@ impl JobDispatcher {
         op: &mut impl es_entity::AtomicOperation,
         id: JobId,
     ) -> Result<(), JobError> {
-        let mut job = self.repo.find_by_id(&id).await?;
+        let mut job = self.repo.find_by_id_in_op(&mut *op, &id).await?;
         sqlx::query!(
             r#"
           DELETE FROM job_executions
@@ -350,7 +350,7 @@ impl JobDispatcher {
         reschedule_at: DateTime<Utc>,
     ) -> Result<(), JobError> {
         self.rescheduled = true;
-        let mut job = self.repo.find_by_id(&id).await?;
+        let mut job = self.repo.find_by_id_in_op(&mut *op, &id).await?;
         sqlx::query!(
             r#"
           UPDATE job_executions


### PR DESCRIPTION
## Summary

- Reuse the database operation already opened for job completion, failure, and rescheduling.
- Prevent concurrent lifecycle transitions from each holding one pool connection while waiting for a second.
- Provide the material fix for [GaloyMoney/lana-bank#7735](https://github.com/GaloyMoney/lana-bank/issues/7735).

## Changes

- Load jobs with `find_by_id_in_op` in the completion path.
- Load jobs with `find_by_id_in_op` in the failure path.
- Load jobs with `find_by_id_in_op` in the rescheduling path.

No schema, behavior, or test changes are needed for this three-line connection-reuse fix.

## Testing

- Validated from `lana-bank` with a 10-connection pool: the full `core-deposit` suite passed 102/102 in 8.76 seconds when using this patched `job` crate.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Three-line internal refactor with identical transaction boundaries; low risk aside from rare edge cases if `find_by_id_in_op` semantics differ from `find_by_id`.
> 
> **Overview**
> **Job lifecycle paths now load entities on the same DB operation** used for execution updates, instead of opening a second read via `find_by_id`.
> 
> In `fail_job`, `complete_job`, and `reschedule_job`, reads switch to `find_by_id_in_op` so failure, completion, and reschedule work no longer hold one pool connection while waiting on another. This is a connection-reuse fix for pool exhaustion under concurrent transitions (e.g. lana-bank #7735); no intended behavior or schema change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fbfc7e40f94a97440a2b9e619e745cd9698cd4fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->