### PR TITLE
fix(deps): update rustls-webpki to 0.103.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1562,9 +1562,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",


### PR DESCRIPTION
## Summary

`cargo audit` flags the pinned `rustls-webpki 0.103.9` (via `sqlx → rustls`, used for TLS Postgres connections) with 4 advisories:

| Advisory | Issue |
|---|---|
| [RUSTSEC-2026-0098](https://rustsec.org/advisories/RUSTSEC-2026-0098) | Name constraints for URI names incorrectly accepted |
| [RUSTSEC-2026-0099](https://rustsec.org/advisories/RUSTSEC-2026-0099) | Name constraints accepted for wildcard certs |
| [RUSTSEC-2026-0104](https://rustsec.org/advisories/RUSTSEC-2026-0104) | Reachable panic in CRL parsing (remote DoS during handshake) |
| [RUSTSEC-2026-0049](https://rustsec.org/advisories/RUSTSEC-2026-0049) | CRLs not authoritative due to faulty Distribution Point matching |

## Change

`cargo update -p rustls-webpki` → **0.103.9 → 0.103.13** (the advisory-patched floor; `Cargo.lock` only, no Cargo.toml change needed).

## Verification

- `cargo audit`: all 4 webpki advisories cleared (only pre-existing allowed warnings remain: `event-listener`, `rand`, yanked `spin`)
- `SQLX_OFFLINE=true cargo check --locked`: compiles cleanly

## Notes

- Remaining audit warnings (`event-listener 5.4.1` unsound, `rand 0.8.5/0.9.2` unsound, `spin 0.9.8` yanked) come transitively via `sqlx`/`es-entity` and need upstream releases — left for a follow-up.
- The existing `audit.yml` workflow (unmaintained `actions-rs/audit-check@v1`) did not surface these; consider switching to `rustsec/audit-check` or `cargo deny` in a separate PR.