### PR TITLE
fix(poller): cap exponential failure backoff to prevent overflow

### DIFF
--- a/src/poller.rs
+++ b/src/poller.rs
@@ -167,7 +167,12 @@ impl JobPoller {
                         failures,
                         "main loop error"
                     );
-                    Duration::from_millis(50 << failures)
+                    // Cap the shift exponent: at ~59 consecutive failures
+                    // `50 << failures` wraps u64 (collapsing the backoff to
+                    // ~0ms and hot-looping against a failing DB), and at 64
+                    // debug builds panic on shift-amount overflow. Capping at
+                    // 12 plateaus the backoff at ~3m25s rather than wrapping.
+                    Duration::from_millis(50 << failures.min(12))
                 }
             };
 
@@ -351,7 +356,9 @@ impl JobPoller {
                                     exception.type = std::any::type_name_of_val(&e),
                                     "keep alive error"
                                 );
-                                Duration::from_millis(50 << failures)
+                                // See main_loop: cap the shift to avoid
+                                // u64 wraparound / debug shift-overflow panic.
+                                Duration::from_millis(50 << failures.min(12))
                             }
                         }
                     }


### PR DESCRIPTION
## Summary

The poller's two error-backoff paths compute `Duration::from_millis(50 << failures)` with an **unbounded** failure counter:

- **`src/poller.rs` main loop** (on `poll_and_dispatch` errors)
- **`src/poller.rs` keep-alive handler** (on heartbeat `UPDATE` errors)

## Problem

With a sustained database outage:

1. At **~59 consecutive failures**, `50 << failures` overflows u64 (bits shifted out wrap), collapsing the backoff to ~0 ms. The loop then hot-spins — re-querying and error-logging as fast as it can — exactly while the DB is already struggling (self-inflicted load amplification).
2. At **64 consecutive failures**, debug builds (shift-overflow checks on) **panic**, crashing the worker process mid-outage.

## Change

Cap the shift exponent at 12 in both places:

```rust
Duration::from_millis(50 << failures.min(12)) // max ≈ 3m25s
```

Behavior is unchanged for the first 12 consecutive failures (50 ms → 51 s → ~3m25s exponential); beyond that the backoff plateaus at **~3m25s** instead of wrapping or panicking. A floor of a few minutes keeps the poller responsive enough to recover quickly once the DB returns, while avoiding the hot-looping/panic failure modes.

## Verification

- `SQLX_OFFLINE=true cargo check` / `cargo clippy`: clean
- `cargo test --lib` unit tests: pass (DB-backed integration tests unchanged)