### PR TITLE
chore: upgrade postgres to 18

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   postgres:
-    image: postgres:16.4
+    image: postgres:18
     ports:
     - "5432:5432"
     environment:

--- a/flake.nix
+++ b/flake.nix
@@ -67,7 +67,7 @@
         cargo-deny
         mdbook
         bacon
-        postgresql
+        postgresql_18
         process-compose
         curl
         ytt
@@ -108,7 +108,7 @@
       pg-start = pkgs.writeShellApplication {
         name = "pg-start";
         runtimeInputs =
-          [pkgs.postgresql pkgs.coreutils]
+          [pkgs.postgresql_18 pkgs.coreutils]
           ++ pkgs.lib.optionals pkgs.stdenv.isLinux [pkgs.util-linux];
         text = ''
           NAME="$1" PORT="$2" PGUSER="$3" DB="$4"
@@ -210,7 +210,7 @@
           exec.command = "${
             pkgs.writeShellApplication {
               name = "ready-${name}";
-              runtimeInputs = [pkgs.postgresql];
+              runtimeInputs = [pkgs.postgresql_18];
               text = ''
                 exec psql -p "''${PGPORT:-${toString port}}" -U ${user} -h 127.0.0.1 -d ${db} -c 'SELECT 1' -t -q
               '';


### PR DESCRIPTION
## Why

lana-bank runs PostgreSQL **18** in every environment (local nix, staging 18.3, QA 18.4). This repo was behind on two fronts:
- `pkgs.postgresql` follows the nixpkgs default (currently 17)
- `docker-compose.yml` pinned `postgres:16.4`

## What

- `flake.nix`: `postgresql` → `postgresql_18` (dev shell `buildInputs`, `pg-start`, readiness probes)
- `docker-compose.yml`: `postgres:16.4` → `postgres:18`

## Verification

- `nix eval .#devShells.<system>.default.drvPath` — evaluates
- `nix develop -c psql --version` → 18.x (verified on the identical obix change)