### PR TITLE
chore(deps): bump es-entity 0.12.0 -> 0.12.3

### DIFF
--- a/.sqlx/query-16fa24cff314e009eafcd4f51d42c9a63e5f90b96eec349022ceebb8a9811ff7.json
+++ b/.sqlx/query-16fa24cff314e009eafcd4f51d42c9a63e5f90b96eec349022ceebb8a9811ff7.json
@@ -1,0 +1,55 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS ((SELECT id FROM jobs WHERE parent_job_id = $1 AND (id < $3) AND ($3 IS NOT NULL) ORDER BY id DESC LIMIT $2) UNION ALL (SELECT id FROM jobs WHERE parent_job_id = $1 AND ($3 IS NULL) ORDER BY id DESC LIMIT $2) ORDER BY id DESC LIMIT $2) SELECT i.id AS \"entity_id!: Repo__Id\", e.sequence, e.event, CASE WHEN $4 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at, NULL::jsonb as \"forgettable_payload?\" FROM entities i JOIN job_events e ON i.id = e.id ORDER BY i.id desc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id!: Repo__Id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "context: es_entity::ContextData",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 4,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 5,
+        "name": "forgettable_payload?",
+        "type_info": "Jsonb"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Int8",
+        "Uuid",
+        "Bool"
+      ]
+    },
+    "nullable": [
+      null,
+      false,
+      false,
+      null,
+      false,
+      null
+    ]
+  },
+  "hash": "16fa24cff314e009eafcd4f51d42c9a63e5f90b96eec349022ceebb8a9811ff7"
+}

--- a/.sqlx/query-5b3037a77724407b2053290aaf999fc11e5be376c0683d5c2024f44636318907.json
+++ b/.sqlx/query-5b3037a77724407b2053290aaf999fc11e5be376c0683d5c2024f44636318907.json
@@ -1,0 +1,54 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS ((SELECT id FROM jobs WHERE parent_job_id IS NULL AND (id < $2) AND ($2 IS NOT NULL) ORDER BY id DESC LIMIT $1) UNION ALL (SELECT id FROM jobs WHERE parent_job_id IS NULL AND ($2 IS NULL) ORDER BY id DESC LIMIT $1) ORDER BY id DESC LIMIT $1) SELECT i.id AS \"entity_id!: Repo__Id\", e.sequence, e.event, CASE WHEN $3 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at, NULL::jsonb as \"forgettable_payload?\" FROM entities i JOIN job_events e ON i.id = e.id ORDER BY i.id desc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id!: Repo__Id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "context: es_entity::ContextData",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 4,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 5,
+        "name": "forgettable_payload?",
+        "type_info": "Jsonb"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Uuid",
+        "Bool"
+      ]
+    },
+    "nullable": [
+      null,
+      false,
+      false,
+      null,
+      false,
+      null
+    ]
+  },
+  "hash": "5b3037a77724407b2053290aaf999fc11e5be376c0683d5c2024f44636318907"
+}

--- a/.sqlx/query-9b01f64afd83cf9e8f36cd15e16c0620748a9e194373ccd660dbdb749edb9cd7.json
+++ b/.sqlx/query-9b01f64afd83cf9e8f36cd15e16c0620748a9e194373ccd660dbdb749edb9cd7.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "WITH entities AS ((SELECT id FROM jobs WHERE (NOT $1 OR parent_job_id IS NOT DISTINCT FROM $2) AND (id < $4) AND ($4 IS NOT NULL) ORDER BY id DESC LIMIT $3) UNION ALL (SELECT id FROM jobs WHERE (NOT $1 OR parent_job_id IS NOT DISTINCT FROM $2) AND ($4 IS NULL) ORDER BY id DESC LIMIT $3) ORDER BY id DESC LIMIT $3) SELECT i.id AS \"entity_id!: Repo__Id\", e.sequence, e.event, CASE WHEN $5 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at, NULL::jsonb as \"forgettable_payload?\" FROM entities i JOIN job_events e ON i.id = e.id ORDER BY i.id desc, i.id, e.sequence",
+  "query": "WITH entities AS ((SELECT created_at, id FROM jobs WHERE parent_job_id = $1 AND ((created_at, id) > ($4, $3)) AND ($3 IS NOT NULL) ORDER BY created_at ASC, id ASC LIMIT $2) UNION ALL (SELECT created_at, id FROM jobs WHERE parent_job_id = $1 AND ($3 IS NULL) ORDER BY created_at ASC, id ASC LIMIT $2) ORDER BY created_at ASC, id ASC LIMIT $2) SELECT i.id AS \"entity_id!: Repo__Id\", e.sequence, e.event, CASE WHEN $5 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at, NULL::jsonb as \"forgettable_payload?\" FROM entities i JOIN job_events e ON i.id = e.id ORDER BY i.created_at asc, i.id asc, i.id, e.sequence",
   "describe": {
     "columns": [
       {
@@ -36,10 +36,10 @@
     ],
     "parameters": {
       "Left": [
-        "Bool",
         "Uuid",
         "Int8",
         "Uuid",
+        "Timestamptz",
         "Bool"
       ]
     },
@@ -52,5 +52,5 @@
       null
     ]
   },
-  "hash": "3adea52924acb821b738406c073b0616ab10dcd860d379356ca682c3c941aa6c"
+  "hash": "9b01f64afd83cf9e8f36cd15e16c0620748a9e194373ccd660dbdb749edb9cd7"
 }

--- a/.sqlx/query-a935f557a2ad8a3be20c45909fb43dc5b1e2c4bbcb6da962e756bf70587514d8.json
+++ b/.sqlx/query-a935f557a2ad8a3be20c45909fb43dc5b1e2c4bbcb6da962e756bf70587514d8.json
@@ -1,0 +1,55 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS ((SELECT created_at, id FROM jobs WHERE parent_job_id IS NULL AND ((created_at, id) < ($3, $2)) AND ($2 IS NOT NULL) ORDER BY created_at DESC, id DESC LIMIT $1) UNION ALL (SELECT created_at, id FROM jobs WHERE parent_job_id IS NULL AND ($2 IS NULL) ORDER BY created_at DESC, id DESC LIMIT $1) ORDER BY created_at DESC, id DESC LIMIT $1) SELECT i.id AS \"entity_id!: Repo__Id\", e.sequence, e.event, CASE WHEN $4 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at, NULL::jsonb as \"forgettable_payload?\" FROM entities i JOIN job_events e ON i.id = e.id ORDER BY i.created_at desc, i.id desc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id!: Repo__Id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "context: es_entity::ContextData",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 4,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 5,
+        "name": "forgettable_payload?",
+        "type_info": "Jsonb"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Uuid",
+        "Timestamptz",
+        "Bool"
+      ]
+    },
+    "nullable": [
+      null,
+      false,
+      false,
+      null,
+      false,
+      null
+    ]
+  },
+  "hash": "a935f557a2ad8a3be20c45909fb43dc5b1e2c4bbcb6da962e756bf70587514d8"
+}

--- a/.sqlx/query-d3eb1b3e6403cd84c52ab9dffab8c9c1b711816ab2b688b2b294daee1e91be9d.json
+++ b/.sqlx/query-d3eb1b3e6403cd84c52ab9dffab8c9c1b711816ab2b688b2b294daee1e91be9d.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "WITH entities AS ((SELECT id FROM jobs WHERE (NOT $1 OR parent_job_id IS NOT DISTINCT FROM $2) AND (id > $4) AND ($4 IS NOT NULL) ORDER BY id ASC LIMIT $3) UNION ALL (SELECT id FROM jobs WHERE (NOT $1 OR parent_job_id IS NOT DISTINCT FROM $2) AND ($4 IS NULL) ORDER BY id ASC LIMIT $3) ORDER BY id ASC LIMIT $3) SELECT i.id AS \"entity_id!: Repo__Id\", e.sequence, e.event, CASE WHEN $5 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at, NULL::jsonb as \"forgettable_payload?\" FROM entities i JOIN job_events e ON i.id = e.id ORDER BY i.id asc, i.id, e.sequence",
+  "query": "WITH entities AS ((SELECT created_at, id FROM jobs WHERE parent_job_id IS NULL AND ((created_at, id) > ($3, $2)) AND ($2 IS NOT NULL) ORDER BY created_at ASC, id ASC LIMIT $1) UNION ALL (SELECT created_at, id FROM jobs WHERE parent_job_id IS NULL AND ($2 IS NULL) ORDER BY created_at ASC, id ASC LIMIT $1) ORDER BY created_at ASC, id ASC LIMIT $1) SELECT i.id AS \"entity_id!: Repo__Id\", e.sequence, e.event, CASE WHEN $4 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at, NULL::jsonb as \"forgettable_payload?\" FROM entities i JOIN job_events e ON i.id = e.id ORDER BY i.created_at asc, i.id asc, i.id, e.sequence",
   "describe": {
     "columns": [
       {
@@ -36,10 +36,9 @@
     ],
     "parameters": {
       "Left": [
-        "Bool",
-        "Uuid",
         "Int8",
         "Uuid",
+        "Timestamptz",
         "Bool"
       ]
     },
@@ -52,5 +51,5 @@
       null
     ]
   },
-  "hash": "3989f6e271552e36658702df298fe8262a8db21eb4490ccfbe52f73a62733384"
+  "hash": "d3eb1b3e6403cd84c52ab9dffab8c9c1b711816ab2b688b2b294daee1e91be9d"
 }

--- a/.sqlx/query-df3a478be7e97dc64db193fed37294109a5a7d8bf5328e04a0257a2ff803abba.json
+++ b/.sqlx/query-df3a478be7e97dc64db193fed37294109a5a7d8bf5328e04a0257a2ff803abba.json
@@ -1,0 +1,54 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS ((SELECT id FROM jobs WHERE parent_job_id IS NULL AND (id > $2) AND ($2 IS NOT NULL) ORDER BY id ASC LIMIT $1) UNION ALL (SELECT id FROM jobs WHERE parent_job_id IS NULL AND ($2 IS NULL) ORDER BY id ASC LIMIT $1) ORDER BY id ASC LIMIT $1) SELECT i.id AS \"entity_id!: Repo__Id\", e.sequence, e.event, CASE WHEN $3 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at, NULL::jsonb as \"forgettable_payload?\" FROM entities i JOIN job_events e ON i.id = e.id ORDER BY i.id asc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id!: Repo__Id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "context: es_entity::ContextData",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 4,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 5,
+        "name": "forgettable_payload?",
+        "type_info": "Jsonb"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Uuid",
+        "Bool"
+      ]
+    },
+    "nullable": [
+      null,
+      false,
+      false,
+      null,
+      false,
+      null
+    ]
+  },
+  "hash": "df3a478be7e97dc64db193fed37294109a5a7d8bf5328e04a0257a2ff803abba"
+}

--- a/.sqlx/query-e776528682c8215abbb81312e9446dc4b8a2a7146d85419585dcd49bc626a470.json
+++ b/.sqlx/query-e776528682c8215abbb81312e9446dc4b8a2a7146d85419585dcd49bc626a470.json
@@ -1,0 +1,55 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS ((SELECT id FROM jobs WHERE parent_job_id = $1 AND (id > $3) AND ($3 IS NOT NULL) ORDER BY id ASC LIMIT $2) UNION ALL (SELECT id FROM jobs WHERE parent_job_id = $1 AND ($3 IS NULL) ORDER BY id ASC LIMIT $2) ORDER BY id ASC LIMIT $2) SELECT i.id AS \"entity_id!: Repo__Id\", e.sequence, e.event, CASE WHEN $4 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at, NULL::jsonb as \"forgettable_payload?\" FROM entities i JOIN job_events e ON i.id = e.id ORDER BY i.id asc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id!: Repo__Id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "context: es_entity::ContextData",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 4,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 5,
+        "name": "forgettable_payload?",
+        "type_info": "Jsonb"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Int8",
+        "Uuid",
+        "Bool"
+      ]
+    },
+    "nullable": [
+      null,
+      false,
+      false,
+      null,
+      false,
+      null
+    ]
+  },
+  "hash": "e776528682c8215abbb81312e9446dc4b8a2a7146d85419585dcd49bc626a470"
+}

--- a/.sqlx/query-f2be0e91cd8f7b8489e22f27d10a2b0bac97e18b6f433dabe7815d596b0dbb3e.json
+++ b/.sqlx/query-f2be0e91cd8f7b8489e22f27d10a2b0bac97e18b6f433dabe7815d596b0dbb3e.json
@@ -1,0 +1,56 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS ((SELECT created_at, id FROM jobs WHERE parent_job_id = $1 AND ((created_at, id) < ($4, $3)) AND ($3 IS NOT NULL) ORDER BY created_at DESC, id DESC LIMIT $2) UNION ALL (SELECT created_at, id FROM jobs WHERE parent_job_id = $1 AND ($3 IS NULL) ORDER BY created_at DESC, id DESC LIMIT $2) ORDER BY created_at DESC, id DESC LIMIT $2) SELECT i.id AS \"entity_id!: Repo__Id\", e.sequence, e.event, CASE WHEN $5 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at, NULL::jsonb as \"forgettable_payload?\" FROM entities i JOIN job_events e ON i.id = e.id ORDER BY i.created_at desc, i.id desc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id!: Repo__Id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "context: es_entity::ContextData",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 4,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 5,
+        "name": "forgettable_payload?",
+        "type_info": "Jsonb"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Int8",
+        "Uuid",
+        "Timestamptz",
+        "Bool"
+      ]
+    },
+    "nullable": [
+      null,
+      false,
+      false,
+      null,
+      false,
+      null
+    ]
+  },
+  "hash": "f2be0e91cd8f7b8489e22f27d10a2b0bac97e18b6f433dabe7815d596b0dbb3e"
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -486,9 +486,9 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "es-entity"
-version = "0.12.0"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eaffadefdf3b88dc6b00398313b2689bed1517bd0ed9cb2fa64761e8d7f2d70"
+checksum = "1c87798b941975265c631a0c4eb350bedad86ac4620012d82e21bc67c5dc44d0"
 dependencies = [
  "async-stream",
  "chrono",
@@ -514,9 +514,9 @@ dependencies = [
 
 [[package]]
 name = "es-entity-macros"
-version = "0.12.0"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c58fe4c10966dffe8e62a4fd7def3806bdae30abf8cfdda5dde9f9918073a620"
+checksum = "3af0555969e3acd0f146741b43831761b32d72339e29944eefc581d4e0db3672"
 dependencies = [
  "convert_case",
  "darling 0.24.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ anyhow = { workspace = true }
 
 [workspace.dependencies]
 
-es-entity = "0.12.0"
+es-entity = "0.12.3"
 
 anyhow = "1.0"
 async-trait = "0.1"

--- a/flake.nix
+++ b/flake.nix
@@ -49,6 +49,9 @@
         src = craneLib.path ./.;
         filter = path: type:
           (builtins.match ".*\.sqlx/.*" path != null)
+          # The EsRepo derive reads migrations/*.sql at macro-expansion time
+          # to build its index catalog; the emitted SQL depends on it.
+          || (builtins.match ".*/migrations/.*\.sql$" path != null)
           || (builtins.match ".*deny\.toml$" path != null)
           || (craneLib.filterCargoSources path type);
       };


### PR DESCRIPTION
## What

Bumps es-entity to 0.12.3 and regenerates the bundled `.sqlx` cache.

## Why

es-entity 0.12.3 (GaloyMoney/es-entity#185) relaxes
`IndexCatalog::specializes` so a filter combo is emitted sargable
whenever its equality columns are a **leading prefix** of some index —
no longer requiring the sort column to immediately follow. Under the
new rule this crate's `JobRepo::list_for_parent_job_id` qualifies via
`idx_jobs_parent_job_id`, so the derive emits:

- `WHERE parent_job_id = $1` / `WHERE parent_job_id IS NULL`
  (sargable, 8 query variants)
- instead of the old `WHERE (NOT $1 OR parent_job_id IS NOT DISTINCT
  FROM $2)` catch-all (2 fallback variants deleted)

## Why the cache refresh must ship in lockstep

Offline query lookup for a **registry** dependency consults the
crate's own bundled `.sqlx` (`manifest_dir/.sqlx`), never the
dependent workspace's cache. So when lana-bank bumps es-entity to
0.12.3, this crate's derive emits the new query text and
`SQLX_OFFLINE=true` compilation fails unless a job release whose
bundled cache contains the new hashes is published first. This PR is
that step; the lana-bank bump PR follows once 0.7.1 is released.

## Testing

- `cargo nextest run`: 63/63 pass (against local Postgres with
  migrations applied)
- `SQLX_OFFLINE=true cargo clippy --all-features --all-targets`: clean
- `cargo fmt --check`: clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes generated SQL for job listing/pagination against Postgres; behavior should be equivalent but query plans and offline-compile coupling to this crate’s `.sqlx` cache are sensitive for dependents.
> 
> **Overview**
> Bumps **es-entity** from 0.12.0 to 0.12.3 in `Cargo.toml` / `Cargo.lock` and refreshes the bundled `.sqlx` offline query cache so `SQLX_OFFLINE=true` builds keep working.
> 
> With es-entity’s relaxed index specialization, `JobRepo::list_for_parent_job_id` now emits **sargable** list queries (`parent_job_id = $1` or `parent_job_id IS NULL`) instead of the old `(NOT $1 OR parent_job_id IS NOT DISTINCT FROM $2)` fallback. The cache gains several new query JSON entries and updates two existing hashes to match the new generated SQL.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c411238ac52cb2a4c0b858dfb2c8d2794edf144. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->