### PR TITLE
perf(job): stop re-planning the poll query; log job_executions autovacuum passes

### DIFF
--- a/migrations/20250904065521_job_setup.sql
+++ b/migrations/20250904065521_job_setup.sql
@@ -59,12 +59,16 @@ CREATE INDEX idx_job_executions_running_queue_id
 -- cost_delay = 0 removes the vacuum throttle: at this table's churn
 -- rate the default 2ms delay reclaims dead tuples slower than they
 -- accumulate, and the poll query's cost grows with the backlog.
+-- log_autovacuum_min_duration = 0 logs every autovacuum pass on this table
+-- (the residual stress-load bloat is naptime/worker/xmin-bound, not tunable
+-- by the triggers above, which already sit at their floor).
 ALTER TABLE job_executions SET (
   fillfactor = 70,
   autovacuum_vacuum_scale_factor = 0.01,
   autovacuum_vacuum_threshold = 50,
   autovacuum_analyze_scale_factor = 0.02,
-  autovacuum_vacuum_cost_delay = 0
+  autovacuum_vacuum_cost_delay = 0,
+  log_autovacuum_min_duration = 0
 );
 
 CREATE OR REPLACE FUNCTION notify_job_event() RETURNS TRIGGER AS $$

--- a/src/poller.rs
+++ b/src/poller.rs
@@ -604,6 +604,14 @@ async fn poll_jobs(
     let wall_now = chrono::Utc::now();
     Span::current().record("now", tracing::field::display(sim_now));
 
+    // Force the generic plan: auto never picks it for this statement, so
+    // every poll re-plans the 6-CTE query (35-54ms vs 0.3ms exec). SET LOCAL
+    // keeps the override off other statements on the caller-shared pool.
+    let mut tx = pool.begin().await?;
+    sqlx::query("SET LOCAL plan_cache_mode = force_generic_plan")
+        .execute(&mut *tx)
+        .await?;
+
     let rows = sqlx::query_as!(
         JobPollRow,
         r#"
@@ -692,8 +700,9 @@ async fn poll_jobs(
         supported_job_types as _,
         wall_now,
     )
-    .fetch_all(pool)
+    .fetch_all(&mut *tx)
     .await?;
+    tx.commit().await?;
 
     Span::current().record("n_jobs_found", rows.len());
     Ok(JobPollResult::from_rows(rows))


### PR DESCRIPTION
## Context

The 2026-08-08 stress soak (`sb-nstr16`, 10 loans/s target — drua `performance` space, `reports/2026-08-08-stress-test-report-sb-nstr16-10lps.md`) profiled the job crate as a steady-state bottleneck:

- **Poll query: 80ms/call, all plan time.** `EXPLAIN ANALYZE` showed 0.3ms execution vs **35–54ms planning** (~308 catalog buffers per plan). At ~2 calls/s that is a permanent ~0.1–0.15 DB core spent re-planning one statement. Postgres' `plan_cache_mode = auto` heuristic **never adopts the generic plan** for the 6-CTE poll statement — the generic-plan cost estimate (default selectivities for the parameterized bounds) always exceeds the average custom-plan cost, so every invocation re-parses and re-plans.
- **`job_executions` dead tuples reached 11× live** (7k → 14.5k vs ~1.3k live), degrading `DELETE` 0.73 → 1.26ms (+73%) and the state-JSON `UPDATE` +15% over the hour.

## Fix 1 — force the generic plan for the poll statement (`src/poller.rs`)

The poll now runs inside a transaction that issues `SET LOCAL plan_cache_mode = force_generic_plan` first. Verified against live PG 18.1 with a production-like seed (~1.3k rows, 40 job types, pending/running mix):

- Generic plan adopted from execution #1; the cached plan persists across transactions on the prepared statement: planning 1.09ms (first build) → **0.005ms** thereafter.
- The generic plan is the *intended* shape per the query's own comments — ordered index scan over `idx_job_executions_pending_execute_at` + nested-loop anti-join — and executed slightly **faster** than the custom plan locally (0.24ms vs 0.30ms, which used a bitmap scan + top-N sort). No "generic plan is worse" fallback needed.
- `SET LOCAL` reverts at transaction end, so no other statement is affected. This matters because the poller has **no dedicated pool**: it polls through the shared repo pool, which in production is caller-supplied (`JobSvcConfig::pool`). A pool-wide `after_connect` hook was rejected — the job crate doesn't construct the pool in that mode, and forcing generic plans pool-wide would risk the inverse of this bug on app queries (cf. cala's `assert_no_double_membership` generic-flip pathology in the 08-07 report addendum).
- Cost: two extra round-trips (`BEGIN`/`SET`/`COMMIT`) at ~2 polls/s — negligible against 35–54ms planning saved per poll.
- Query text unchanged → no `.sqlx` churn.

Known trade-off: the generic plan filters `job_type = ANY($4)` *after* the ordered scan instead of using the composite `(job_type, execute_at)` index. Fine when a poller registers all job types (our deployment); a poller supporting few types amid many due jobs of other types would over-scan, bounded by the due-set LIMIT.

## Fix 2 — `log_autovacuum_min_duration = 0` on `job_executions` (migration, edited in place — fresh-deploy convention, no in-place ALTER script)

The original ask was to make autovacuum storage params more aggressive. **The data says there's nothing left to tighten:**

- #141 (`fillfactor=70`, `autovacuum_vacuum_scale_factor=0.01`, `autovacuum_vacuum_threshold=50`) and #142 (`cost_delay=0`) were **already in 0.7.1**, the release under test. The vacuum trigger already fires at ~63 dead tuples.
- A 150s pgbench churn bench (250 tps heartbeat/state-JSON/state-flip mix on a production-like seed) shows dead tuples saw-toothing 0 → 2.9k (2.3× live) → 0 with a period of **exactly 60s = global `autovacuum_naptime`** — the trigger fires immediately every cycle; the ceiling is the naptime, which is not per-table tunable.
- Re-running with `fillfactor=50`: identical slope, identical ~70% HOT-update ratio. Speculative fillfactor lowering buys nothing at this churn.
- The production 11× (monotonic growth, not a sawtooth) therefore points at naptime floor × higher churn plus **vacuum-worker starvation** (3 workers vs the 784MB outbox partitions needing constant vacuuming) and/or **xmin holdback** from obix's back-to-back 8.2–9.5s gap-fill transactions (report §2.1) keeping tuples "dead but not yet removable".

So instead of placebo tuning, this PR adds `log_autovacuum_min_duration = 0` to the table's storage params: every autovacuum pass on `job_executions` gets logged (cadence, tuples removed, dead-but-not-removable counts), letting the next stress run attribute the bloat definitively.

**Deployment-level recommendations** (out of scope for this crate, for the stress-env/prod config): `autovacuum_naptime` 60s → 10–15s and/or more autovacuum workers; and the obix gap-fill fix already tracked as a report action item (shorter transactions directly shrink the unremovable-dead window).

## Commits

Two commits: the poller change and the migration change are independent; the migration commit is isolated so it can be sequenced/rebased cleanly against the in-flight JobHandle work (task 019fe306), which touches the same migration file's `jobs`/`queue_id` DDL. The storage-param block edit at the bottom of the file does not overlap those lines.

## Verification

- `nix flake check` (fmt, clippy `-D warnings`, nextest) — green
- Live-PG integration suite (`cargo nextest run` against `make start-deps` PG 18.1) — green, includes the queue-serialization / two-poller / clock poll-path tests
- `EXPLAIN (ANALYZE)` before/after on the prepared poll statement as above
- Migration applies fresh with the new param: `reloptions = {fillfactor=70,autovacuum_vacuum_scale_factor=0.01,autovacuum_vacuum_threshold=50,autovacuum_analyze_scale_factor=0.02,autovacuum_vacuum_cost_delay=0,log_autovacuum_min_duration=0}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the hot-path poll query execution model (transaction + plan cache mode) on shared DB pools; behavior is intentional but affects core job scheduling throughput and must stay scoped via SET LOCAL.
> 
> **Overview**
> Addresses stress-test profiling where each job poll spent **35–54ms planning** the six-CTE statement while execution stayed ~0.3ms, because Postgres `plan_cache_mode = auto` never cached a generic plan.
> 
> **Poller:** The poll now runs inside a short transaction that sets **`SET LOCAL plan_cache_mode = force_generic_plan`** before the existing poll SQL, then commits. `SET LOCAL` limits the override to that transaction so other statements on the shared pool are unaffected. Planning drops to negligible after the first build; extra `BEGIN`/`COMMIT` round-trips are small versus saved plan time.
> 
> **Migration:** `job_executions` storage params add **`log_autovacuum_min_duration = 0`** so every autovacuum pass on that table is logged, supporting diagnosis of dead-tuple bloat when naptime/worker limits dominate (existing aggressive vacuum triggers were already at their floor).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd2791eff3f92d7ce280ece1e7ec98e226e2d18b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->