### PR TITLE
feat(batched): per-item savepoint isolation via CurrentBatchedJob::run_isolated

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -476,9 +476,9 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "es-entity"
-version = "0.12.7"
+version = "0.12.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f9f94a1c1d074fbe3ea443d6c6a476a80af6f16ea794fcb6be4bb1bdeddd7f3"
+checksum = "d95910d8d6cc11fd6e61c433cff8cd0468c74af1097a660b259d80a8b219ec06"
 dependencies = [
  "async-stream",
  "chrono",
@@ -504,9 +504,9 @@ dependencies = [
 
 [[package]]
 name = "es-entity-macros"
-version = "0.12.7"
+version = "0.12.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f846f97468b73de4d70059c6c89adf5606dfdd3b08f7d98f2093e9b534d699c"
+checksum = "97b3c4e81740f9566e80714bd1ebab3485574c44b25f47495b4e81869193656c"
 dependencies = [
  "convert_case",
  "darling 0.24.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ anyhow = { workspace = true }
 
 [workspace.dependencies]
 
-es-entity = "0.12.7"
+es-entity = "0.12.8"
 
 anyhow = "1.0"
 async-trait = "0.1"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -13,7 +13,7 @@ libfuzzer-sys = "0.4"
 job = { path = ".." }
 # The hydration machinery (`EntityEvents`, `GenericEvent`, …) lives in
 # es-entity; pin the same version `job` depends on so the impls unify.
-es-entity = "0.12.7"
+es-entity = "0.12.8"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 chrono = { version = "0.4", features = ["clock"], default-features = false }

--- a/src/batched.rs
+++ b/src/batched.rs
@@ -30,6 +30,13 @@
 //!   Pick `queue_id` to be whatever you need serialized.
 //! - **Do not perform external calls** (HTTP, mail, RPC) inside a shared batch
 //!   transaction — keep those job types on the per-job [`JobRunner`](crate::JobRunner).
+//! - A per-item **DB** error (a constraint violation, say) run straight
+//!   against the batch's `op` aborts the whole transaction. To isolate it —
+//!   so batch-mates still commit — run that item's work through
+//!   [`CurrentBatchedJob::run_isolated`], which wraps each item in its own
+//!   `SAVEPOINT` via [`es_entity::DbOp::with_savepoint`]. Savepoints isolate
+//!   *failures*, not *contention*: they do not release Postgres locks, so
+//!   they are not a lever for raising batch size under lock pressure.
 
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
@@ -142,10 +149,17 @@ pub enum BatchItemOutcome {
     /// Treat this job as failed: it is retried per the type's
     /// [`RetrySettings`], or marked errored once attempts are exhausted.
     ///
-    /// Only for failures detected **without** poisoning the shared transaction
-    /// (validation, missing precondition, a domain rule saying "no"). A failed
-    /// SQL statement aborts the whole transaction — return `Err` from
-    /// `run_batch` in that case so the entire batch is retried.
+    /// For failures detected without poisoning the shared transaction
+    /// (validation, missing precondition, a domain rule saying "no"), just
+    /// return this outcome directly. A failed SQL statement run straight
+    /// against the batch's `op` still aborts the whole transaction — return
+    /// `Err` from `run_batch` in that case so the entire batch is retried.
+    /// To let a per-item **DB** error resolve to this outcome too, without
+    /// taking batch-mates down with it, run that item's work through
+    /// [`CurrentBatchedJob::run_isolated`] (or
+    /// [`es_entity::DbOp::with_savepoint`] directly): the savepoint rolls
+    /// back only that item's writes, and the shared transaction stays usable
+    /// for the rest of the batch.
     Fail(String),
 }
 
@@ -353,6 +367,64 @@ impl<C> CurrentBatchedJob<C> {
     #[cfg(feature = "es-entity")]
     pub async fn begin_op(&self) -> Result<es_entity::DbOp<'static>, JobError> {
         Ok(es_entity::DbOp::init_with_clock(&self.pool, &self.clock).await?)
+    }
+
+    /// Run `f` once per item, each inside its own `SAVEPOINT` on `op`, and
+    /// collect a [`BatchOutcomes`] — the batch-loop counterpart of
+    /// [`es_entity::DbOp::with_savepoint`].
+    ///
+    /// A failing item is rolled back to its own savepoint without poisoning
+    /// `op`: earlier and later items still commit in the same transaction.
+    /// `f`'s `Ok(outcome)` is recorded as-is — usually
+    /// [`BatchItemOutcome::Complete`], though a successfully-released
+    /// savepoint can still resolve to `RescheduleIn`/`RescheduleAt` if the
+    /// item wants to run again later. `f`'s `Err` is translated to
+    /// [`BatchItemOutcome::Fail`] (via `E`'s `Display`), so the item is
+    /// retried per the type's [`RetrySettings`] like any other failure.
+    ///
+    /// Typical use, feeding the result into
+    /// [`JobBatchCompletion::WithOutcomesWithOp`]:
+    ///
+    /// ```rust,ignore
+    /// let mut op = current_batch.begin_op().await?;
+    /// let outcomes = current_batch
+    ///     .run_isolated(&mut op, |op, item| async move {
+    ///         self.execute_in_op(op, item.config()).await?;
+    ///         Ok(BatchItemOutcome::Complete)
+    ///     })
+    ///     .await?;
+    /// Ok(JobBatchCompletion::WithOutcomesWithOp(op, outcomes))
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// The returned `Err` is the *outer* layer of
+    /// [`with_savepoint`](es_entity::DbOp::with_savepoint): the savepoint
+    /// machinery itself failed (e.g. a dead connection), not any one item's
+    /// domain logic. That failure isn't attributable to a single item —
+    /// propagate it with `?` and let the whole batch retry, exactly like a
+    /// whole-batch `Err` returned from `run_batch` today.
+    #[cfg(feature = "es-entity")]
+    pub async fn run_isolated<E>(
+        &self,
+        op: &mut es_entity::DbOp<'static>,
+        f: impl AsyncFn(
+            &mut es_entity::SavepointOp<'_>,
+            &BatchedJobItem<C>,
+        ) -> Result<BatchItemOutcome, E>,
+    ) -> Result<BatchOutcomes, sqlx::Error>
+    where
+        E: std::fmt::Display,
+    {
+        let mut outcomes = Vec::with_capacity(self.items.len());
+        for item in &self.items {
+            let outcome = match op.with_savepoint(async |sp| f(sp, item).await).await? {
+                Ok(outcome) => outcome,
+                Err(e) => BatchItemOutcome::Fail(e.to_string()),
+            };
+            outcomes.push((item.id, outcome));
+        }
+        Ok(outcomes)
     }
 
     /// Build a [`BatchOutcomes`] by deciding an outcome for every item.

--- a/tests/batched_job_savepoint.rs
+++ b/tests/batched_job_savepoint.rs
@@ -1,0 +1,274 @@
+//! Live-PG coverage for `CurrentBatchedJob::run_isolated` — per-item
+//! `SAVEPOINT` isolation inside a shared batch transaction (es-entity
+//! 0.12.8's `DbOp::with_savepoint`).
+//!
+//! The contract under test: a per-item **DB** error no longer poisons the
+//! whole batch transaction. Before this, any error surfacing from a
+//! statement run directly against a batch's `op` aborted the entire shared
+//! transaction — every item in the batch, including ones that had nothing to
+//! do with the failure, went through the whole-batch retry path. With
+//! `run_isolated`, a failing item's writes unwind to its own savepoint and
+//! the rest of the batch still commits in the same transaction.
+#![cfg(feature = "es-entity")]
+
+mod helpers;
+
+use async_trait::async_trait;
+use es_entity::AtomicOperation;
+use job::{
+    BatchItemOutcome, BatchedJobInitializer, BatchedJobRunner, CurrentBatchedJob,
+    JobBatchCompletion, JobId, JobSpawner, JobSpec, JobSvcConfig, JobTerminalState, JobType, Jobs,
+    RetrySettings,
+};
+use serde::{Deserialize, Serialize};
+use std::time::Duration;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct SavepointConfig {
+    label: String,
+    /// Scratch table this item writes into. Carried on the config (rather
+    /// than captured from the runner) so the closure passed to
+    /// `run_isolated` captures nothing from `run_batch`'s environment —
+    /// everything it needs arrives through `item`.
+    table: String,
+    /// Items sharing the same key race for the same row in `table`: the
+    /// first insert wins, every later one hits a genuine Postgres
+    /// unique-violation inside its own savepoint.
+    conflict_key: Option<i32>,
+}
+
+/// Inserts `config.conflict_key` into `config.table` through
+/// [`CurrentBatchedJob::run_isolated`] — only on an item's first attempt, so
+/// a retried item (always dispatched solo, one attempt later) finds nothing
+/// standing in its way, the same way a real transient DB failure would clear
+/// by the next try.
+struct SavepointInitializer {
+    job_type: JobType,
+    n_attempts: Option<u32>,
+}
+
+impl BatchedJobInitializer for SavepointInitializer {
+    type Config = SavepointConfig;
+
+    fn job_type(&self) -> JobType {
+        self.job_type.clone()
+    }
+
+    fn retry_on_error_settings(&self) -> RetrySettings {
+        RetrySettings {
+            n_attempts: self.n_attempts,
+            min_backoff: Duration::from_millis(10),
+            max_backoff: Duration::from_millis(50),
+            ..Default::default()
+        }
+    }
+
+    fn init(
+        &self,
+        _: JobSpawner<Self::Config>,
+    ) -> Result<Box<dyn BatchedJobRunner<Config = Self::Config>>, Box<dyn std::error::Error>> {
+        Ok(Box::new(SavepointRunner))
+    }
+}
+
+struct SavepointRunner;
+
+#[async_trait]
+impl BatchedJobRunner for SavepointRunner {
+    type Config = SavepointConfig;
+
+    async fn run_batch(
+        &self,
+        current_batch: CurrentBatchedJob<SavepointConfig>,
+    ) -> Result<JobBatchCompletion, Box<dyn std::error::Error>> {
+        let mut op = current_batch.begin_op().await?;
+        let outcomes = current_batch
+            .run_isolated(&mut op, async |sp, item| {
+                if item.attempt() == 1
+                    && let Some(key) = item.config().conflict_key
+                {
+                    sqlx::query(&format!(
+                        "INSERT INTO {} (v) VALUES ($1)",
+                        item.config().table
+                    ))
+                    .bind(key)
+                    .execute(sp.as_executor())
+                    .await?;
+                }
+                Ok::<_, sqlx::Error>(BatchItemOutcome::Complete)
+            })
+            .await?;
+        Ok(JobBatchCompletion::WithOutcomesWithOp(op, outcomes))
+    }
+}
+
+/// Drops and recreates a scratch table with a `PRIMARY KEY` constraint, so
+/// each test starts from a clean slate regardless of leftovers from a
+/// previous run. A real (non-temporary) table on purpose: it must produce a
+/// genuine conflict even if the racing items land in different batches on
+/// different pooled connections, not just within one transaction.
+async fn reset_scratch_table(pool: &sqlx::PgPool, table: &str) -> anyhow::Result<()> {
+    sqlx::query(&format!("DROP TABLE IF EXISTS {table}"))
+        .execute(pool)
+        .await?;
+    sqlx::query(&format!("CREATE TABLE {table} (v INT PRIMARY KEY)"))
+        .execute(pool)
+        .await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn run_isolated_keeps_batch_mates_committing_after_a_per_item_db_error() -> anyhow::Result<()>
+{
+    let table = "batched_savepoint_test_conflict";
+    let pool = helpers::init_pool().await?;
+    reset_scratch_table(&pool, table).await?;
+
+    let config = JobSvcConfig::builder().pool(pool).build().unwrap();
+    let mut jobs = Jobs::init(config).await?;
+
+    let spawner = jobs.add_batched_initializer(SavepointInitializer {
+        job_type: JobType::new("batched-savepoint-conflict"),
+        // Terminal on the first failure: keeps this test's assertions about
+        // the *first pass* unambiguous (no retry churn to account for).
+        n_attempts: Some(1),
+    });
+
+    // Three items race for the same row: exactly one insert can win.
+    let conflict_ids: Vec<JobId> = (0..3).map(|_| JobId::new()).collect();
+    // Two conflict-free controls: their only job is to prove the shared
+    // transaction stayed usable after the conflicting items' savepoints
+    // rolled back.
+    let ok_ids: Vec<JobId> = (0..2).map(|_| JobId::new()).collect();
+
+    let mut specs: Vec<JobSpec<SavepointConfig>> = conflict_ids
+        .iter()
+        .enumerate()
+        .map(|(i, id)| {
+            JobSpec::new(
+                *id,
+                SavepointConfig {
+                    label: format!("conflict-{i}"),
+                    table: table.to_string(),
+                    conflict_key: Some(1),
+                },
+            )
+        })
+        .collect();
+    specs.extend(ok_ids.iter().enumerate().map(|(i, id)| {
+        JobSpec::new(
+            *id,
+            SavepointConfig {
+                label: format!("ok-{i}"),
+                table: table.to_string(),
+                conflict_key: None,
+            },
+        )
+    }));
+    spawner.spawn_all(specs).await?;
+
+    jobs.start_poll().await?;
+
+    let all: Vec<JobId> = conflict_ids.iter().chain(ok_ids.iter()).copied().collect();
+    let outcomes = jobs
+        .handles(all.clone())
+        .await_all(Duration::from_secs(30))
+        .await?;
+
+    // The conflict-free controls must complete. Pre-savepoint, a per-item DB
+    // error run straight against the batch's `op` would abort the whole
+    // transaction and take these down with the conflicting items on every
+    // attempt (the batch keeps re-forming with the same losers) — this is
+    // the assertion that actually distinguishes isolation from poisoning.
+    for outcome in outcomes.iter().skip(3) {
+        assert_eq!(
+            outcome.state(),
+            JobTerminalState::Completed,
+            "a conflict-free batch-mate must complete regardless of another \
+             item's DB error"
+        );
+    }
+
+    // Of the three racing items, exactly one wins the insert and completes;
+    // the other two roll back to their own savepoint and, with n_attempts=1,
+    // surface as Errored rather than dragging the batch down.
+    let conflict_states: Vec<_> = outcomes.iter().take(3).map(|o| o.state()).collect();
+    let completed = conflict_states
+        .iter()
+        .filter(|s| **s == JobTerminalState::Completed)
+        .count();
+    let errored = conflict_states
+        .iter()
+        .filter(|s| **s == JobTerminalState::Errored)
+        .count();
+    assert_eq!(
+        completed, 1,
+        "exactly one conflicting item should win the insert, saw {conflict_states:?}"
+    );
+    assert_eq!(
+        errored, 2,
+        "the losing items must be isolated failures, not a batch-wide one, \
+         saw {conflict_states:?}"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn run_isolated_failed_item_retries_solo_and_recovers() -> anyhow::Result<()> {
+    let table = "batched_savepoint_test_retry";
+    let pool = helpers::init_pool().await?;
+    reset_scratch_table(&pool, table).await?;
+
+    let config = JobSvcConfig::builder().pool(pool).build().unwrap();
+    let mut jobs = Jobs::init(config).await?;
+
+    let spawner = jobs.add_batched_initializer(SavepointInitializer {
+        job_type: JobType::new("batched-savepoint-retry"),
+        n_attempts: Some(5),
+    });
+
+    // Two items share a key: the loser's first attempt hits a real
+    // unique-violation inside its savepoint, is translated to `Fail`, and is
+    // retried per the type's `RetrySettings` — same as any other batched
+    // failure, proving savepoint isolation doesn't disturb the existing
+    // retry-solo rule (attempt > 1 is always dispatched alone). Its second
+    // attempt skips the insert (see `SavepointRunner`) and completes.
+    let winner_id = JobId::new();
+    let loser_id = JobId::new();
+    let specs = vec![
+        JobSpec::new(
+            winner_id,
+            SavepointConfig {
+                label: "winner".into(),
+                table: table.to_string(),
+                conflict_key: Some(7),
+            },
+        ),
+        JobSpec::new(
+            loser_id,
+            SavepointConfig {
+                label: "loser".into(),
+                table: table.to_string(),
+                conflict_key: Some(7),
+            },
+        ),
+    ];
+    spawner.spawn_all(specs).await?;
+
+    jobs.start_poll().await?;
+
+    let outcomes = jobs
+        .handles(vec![winner_id, loser_id])
+        .await_all(Duration::from_secs(30))
+        .await?;
+    assert!(
+        outcomes
+            .iter()
+            .all(|o| o.state() == JobTerminalState::Completed),
+        "both the immediate winner and the retried loser should complete, saw {:?}",
+        outcomes.iter().map(|o| o.state()).collect::<Vec<_>>()
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
## What

Adds `CurrentBatchedJob::run_isolated` (feature = `"es-entity"`), built on
es-entity 0.12.8's new `DbOp::with_savepoint` primitive: runs each batch
item's work inside its own `SAVEPOINT` on the batch's shared `op`, so a
per-item **DB** error (constraint violation, etc.) rolls back only that
item's writes instead of poisoning the whole batch transaction. Feeds the
existing `JobBatchCompletion::WithOutcomesWithOp(op, outcomes)` — no new
completion variant needed.

```rust
let mut op = current_batch.begin_op().await?;
let outcomes = current_batch
    .run_isolated(&mut op, async |op, item| {
        self.execute_in_op(op, item.config()).await?;
        Ok(BatchItemOutcome::Complete)
    })
    .await?;
Ok(JobBatchCompletion::WithOutcomesWithOp(op, outcomes))
```

`f`'s `Ok(outcome)` is recorded as-is (usually `Complete`, though a
successfully-released savepoint can still resolve to
`RescheduleIn`/`RescheduleAt`). `f`'s `Err` is translated to
`BatchItemOutcome::Fail` (via `Display`) and goes through the type's normal
`RetrySettings` — the same path as any other batched failure.

Bumps the `es-entity` pin from 0.12.7 → 0.12.8 (Cargo.toml, fuzz/Cargo.toml,
Cargo.lock) for `DbOp::with_savepoint` / `begin_savepoint` / `SavepointOp`.

## Why

`design-batched-job-runner.md`'s cala-precedent note ("no savepoints — cala
measured the cost too high") was cala's call for cala's hot path, not a
statement that savepoints don't work for `job` — see
`design-savepoint-batch-isolation.md`. The actual blocker was structural:
`DbOp` had no nested-transaction API whose commit hooks behaved correctly at
a savepoint boundary (staged hooks fold into the parent on release, drop on
rollback — no phantom outbox publish for a row that no longer exists).
es-entity 0.12.8 (GaloyMoney/es-entity#199) fixes that gap at the primitive
level; this PR is the `job`-side consumer the design doc's follow-up work
item 2 calls for ("ship a loop helper so adopters don't hand-roll it").

Previously documented in clat memory as the BatchedJobRunner design's
explicit "per-item outcomes only cover non-poisoning failures" constraint —
that constraint is now narrower: it only applies to work run directly
against the batch's `op`, not to work isolated through `run_isolated`.

## Non-goals (per the design doc, unchanged here)

- **Retry-solo rule unchanged.** `attempt > 1` is still always dispatched
  alone. The design doc flags "revisit this" as an open future-work item,
  not a decision — out of scope here, confirmed via a live test
  (`run_isolated_failed_item_retries_solo_and_recovers`).
- **No contention/lock relief.** Savepoints don't release Postgres locks;
  this is not a lever for raising batch size under lock pressure (documented
  on the `run_isolated` guidance bullet in the module doc).
- **One level of savepoint nesting only** (matches es-entity's v1 scope) —
  not relevant to a flat batch loop.
- Does not touch `es-entity`, `obix`, `cala`, or `lana` — those are separate
  follow-ups. obix + lana `BatchedJobRunner` consumers can adopt per-item
  DB-error isolation once this releases; flagging only.

## Testing

New file `tests/batched_job_savepoint.rs` (live-PG, gated
`#![cfg(feature = "es-entity")]`):

- `run_isolated_keeps_batch_mates_committing_after_a_per_item_db_error` — 3
  items race for the same row in a scratch table (real unique-violation
  inside their own savepoints), 2 conflict-free controls. Asserts exactly 1
  of the 3 wins and 2 error out *individually*, while both controls still
  complete — the core claim that a per-item DB error no longer poisons the
  shared transaction the rest of the batch commits in.
- `run_isolated_failed_item_retries_solo_and_recovers` — a losing item's
  savepoint-isolated failure is retried per `RetrySettings` (dispatched
  alone, per the existing retry-solo rule) and succeeds once the transient
  condition clears.

Verified:
- `nix flake check` (fmt, clippy `--all-features -D warnings`, audit, deny) —
  clean.
- `cargo nextest run --workspace` (default features, matching CI's
  `nix run .#nextest`) — 88/88 existing tests pass unchanged (the new file
  compiles to nothing without the `es-entity` feature, by design).
- `cargo nextest run --workspace --features es-entity` against live PG
  (`make start-deps`) — 90/90 pass (88 existing + 2 new).

**Note for reviewers:** `nix run .#nextest` (the packaged CI test runner)
invokes `cargo nextest run --workspace --verbose` with no `--features`
flag, so the `es-entity`-gated surface — `CompleteAllWithOp`,
`WithOutcomesWithOp`, `begin_op`, and now `run_isolated` — isn't exercised
by the default CI test run today. That's a pre-existing gap (predates this
PR; no existing test uses those variants either) rather than something
introduced here, but worth a deliberate call on whether `nextest-runner`
should pass `--features es-entity` going forward. Left untouched to keep
this PR's diff scoped to the design.

Refs: `job-dev/design-savepoint-batch-isolation.md`,
`job-dev/design-batched-job-runner.md` (rev 4, memory 019ff9b3),
GaloyMoney/es-entity#199, GaloyMoney/job#165

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes batched transaction semantics and depends on new es-entity savepoint behavior; misusing `op` without `run_isolated` can still poison batches, but the new path is on the critical batch commit path.
> 
> **Overview**
> Bumps **`es-entity`** from 0.12.7 to **0.12.8** so batched runners can use `DbOp::with_savepoint`.
> 
> Adds **`CurrentBatchedJob::run_isolated`** (with the `es-entity` feature): it runs each batch item inside its own Postgres `SAVEPOINT` on the shared batch `DbOp`, maps per-item `Err` to `BatchItemOutcome::Fail`, and returns outcomes for **`WithOutcomesWithOp`**—so one item’s DB error no longer aborts the whole batch transaction.
> 
> Module docs and **`BatchItemOutcome::Fail`** are updated to describe when to use direct `op` vs `run_isolated`, and that savepoints isolate failures but not lock contention.
> 
> New live-PG tests in **`tests/batched_job_savepoint.rs`** cover batch-mates still completing after a per-item unique violation and solo retry recovery for the loser.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d88d2c9d662030e1010be14f469d0e4c842ebd14. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->