### PR TITLE
fix(poller): stop poll loop before draining at shutdown

### DIFF
--- a/src/poller.rs
+++ b/src/poller.rs
@@ -72,10 +72,26 @@ pub(crate) struct JobPollerHandle {
     router_listener_handle: OwnedTaskHandle,
     #[allow(dead_code)]
     router_waiter_handle: OwnedTaskHandle,
+    shutdown: Arc<ShutdownCoordinator>,
+}
+
+/// Drives the shutdown sequence for one poller instance.
+///
+/// Shared behind an `Arc` so the explicit [`JobPollerHandle::shutdown`] call and
+/// the drop path run the identical sequence, guarded by the same
+/// `shutdown_called` flag.
+struct ShutdownCoordinator {
     shutdown_tx: tokio::sync::broadcast::Sender<
         tokio::sync::mpsc::Sender<tokio::sync::oneshot::Receiver<()>>,
     >,
-    shutdown_called: Arc<AtomicBool>,
+    /// Tells `main_loop` to stop polling. Separate from `shutdown_tx` on
+    /// purpose: the poll loop must be stopped and *drained* before the monitors
+    /// are signalled (see [`ShutdownCoordinator::perform`]).
+    poll_stop_tx: tokio::sync::watch::Sender<bool>,
+    /// Flipped by `main_loop` once it has left the loop. A dropped sender (the
+    /// task was aborted or panicked) counts as "exited" too.
+    poll_exited_rx: tokio::sync::watch::Receiver<bool>,
+    shutdown_called: AtomicBool,
     shutdown_timeout: Duration,
     max_jobs_per_process: usize,
     repo: Arc<JobRepo>,
@@ -129,11 +145,15 @@ impl JobPoller {
         let shutdown_timeout = self.config.shutdown_timeout;
         let max_jobs_per_process = self.config.max_jobs_per_process;
         let clock = self.clock.clone();
+        let (poll_stop_tx, poll_stop_rx) = tokio::sync::watch::channel(false);
+        let (poll_exited_tx, poll_exited_rx) = tokio::sync::watch::channel(false);
         let executor = Arc::new(self);
         let handle = OwnedTaskHandle::new(spawn_named_task!(
             "job-poller-main-loop",
             Self::main_loop(
                 Arc::clone(&executor),
+                poll_stop_rx,
+                poll_exited_tx,
                 lost_handle,
                 keep_alive_handle,
                 stale_jobs_handle,
@@ -144,29 +164,48 @@ impl JobPoller {
             handle,
             router_listener_handle,
             router_waiter_handle,
-            shutdown_tx,
-            shutdown_called: Arc::new(AtomicBool::new(false)),
-            repo,
-            instance_id,
-            shutdown_timeout,
-            max_jobs_per_process,
-            clock,
+            shutdown: Arc::new(ShutdownCoordinator {
+                shutdown_tx,
+                poll_stop_tx,
+                poll_exited_rx,
+                shutdown_called: AtomicBool::new(false),
+                repo,
+                instance_id,
+                shutdown_timeout,
+                max_jobs_per_process,
+                clock,
+            }),
         }
     }
 
+    /// Claim-and-dispatch loop.
+    ///
+    /// Stopping is driven by `poll_stop_rx` — a `watch`, not the
+    /// `shutdown_tx` broadcast, because the stop must *latch*: a
+    /// `poll_and_dispatch()` already in flight when the signal lands has to see
+    /// it on the very next check rather than miss a one-shot notification. The
+    /// loop leaves an in-flight poll intact (every row it claimed still gets
+    /// dispatched, so no claim is stranded in `state='running'`) and then flips
+    /// `poll_exited_tx`, which is what
+    /// [`ShutdownCoordinator::perform`] waits for before signalling the
+    /// monitors.
     async fn main_loop(
         self: Arc<Self>,
+        mut poll_stop_rx: tokio::sync::watch::Receiver<bool>,
+        poll_exited_tx: tokio::sync::watch::Sender<bool>,
         _lost_task: OwnedTaskHandle,
         _keep_alive_task: OwnedTaskHandle,
         _stale_jobs_task: OwnedTaskHandle,
     ) {
         let mut failures = 0;
         let mut woken_up = false;
-        let mut shutdown_rx = self.shutdown_tx.subscribe();
         let debounce = self.config.poll_debounce;
         let mut last_poll = std::time::Instant::now();
 
         loop {
+            if *poll_stop_rx.borrow_and_update() {
+                break;
+            }
             if woken_up {
                 let since = last_poll.elapsed();
                 if since < debounce {
@@ -195,7 +234,7 @@ impl JobPoller {
             tokio::select! {
                 biased;
 
-                _ = shutdown_rx.recv() => {
+                _ = poll_stop_rx.changed() => {
                     break;
                 }
                 result = self.clock.timeout(timeout, self.tracker.notified()) => {
@@ -203,6 +242,9 @@ impl JobPoller {
                 }
             }
         }
+
+        // Reported after the loop is provably done claiming rows.
+        let _ = poll_exited_tx.send(true);
     }
 
     #[instrument(
@@ -1170,131 +1212,182 @@ impl JobPollerHandle {
     ///
     /// If not called manually, it will be called automatically when the handle is dropped.
     pub async fn shutdown(&self) -> Result<(), JobError> {
-        perform_shutdown(
-            self.shutdown_tx.clone(),
-            Arc::clone(&self.repo),
-            self.instance_id,
-            self.shutdown_called.clone(),
-            self.shutdown_timeout,
-            self.max_jobs_per_process,
-            self.clock.clone(),
-        )
-        .await
+        self.shutdown.perform().await
     }
 }
 
 impl Drop for JobPollerHandle {
     fn drop(&mut self) {
-        let shutdown_tx = self.shutdown_tx.clone();
-        let repo = Arc::clone(&self.repo);
-        let instance_id = self.instance_id;
-        let shutdown_called = self.shutdown_called.clone();
-        let shutdown_timeout = self.shutdown_timeout;
-        let max_jobs_per_process = self.max_jobs_per_process;
-        let clock = self.clock.clone();
-
+        let shutdown = Arc::clone(&self.shutdown);
         spawn_named_task!("job-poller-shutdown-on-drop", async move {
-            let _ = perform_shutdown(
-                shutdown_tx,
-                repo,
-                instance_id,
-                shutdown_called,
-                shutdown_timeout,
-                max_jobs_per_process,
-                clock,
-            )
-            .await;
+            let _ = shutdown.perform().await;
         });
     }
 }
 
-#[instrument(
-    name = "jobs.perform_shutdown",
-    skip(shutdown_tx, repo, clock),
-    fields(n_jobs, instance_id = %instance_id, broadcast_ok, n_responses)
-)]
-async fn perform_shutdown(
-    shutdown_tx: tokio::sync::broadcast::Sender<
-        tokio::sync::mpsc::Sender<tokio::sync::oneshot::Receiver<()>>,
-    >,
-    repo: Arc<JobRepo>,
-    instance_id: uuid::Uuid,
-    shutdown_called: Arc<AtomicBool>,
-    shutdown_timeout: Duration,
-    max_jobs_per_process: usize,
-    clock: ClockHandle,
-) -> Result<(), JobError> {
-    if shutdown_called
-        .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
-        .is_err()
-    {
-        return Ok(());
-    }
-
-    let (send, mut recv) =
-        tokio::sync::mpsc::channel::<tokio::sync::oneshot::Receiver<()>>(max_jobs_per_process);
-
-    let broadcast_ok = shutdown_tx.send(send).is_ok();
-    tracing::Span::current().record("broadcast_ok", broadcast_ok);
-
-    if broadcast_ok {
-        let mut receivers = Vec::with_capacity(max_jobs_per_process);
-        let receive_timeout = Duration::from_millis(100);
-
-        tracing::info!("Starting to collect shutdown acknowledgements from job monitors");
-
-        loop {
-            match tokio::time::timeout(receive_timeout, recv.recv()).await {
-                Ok(Some(oneshot_rx)) => {
-                    receivers.push(oneshot_rx);
-                    tracing::info!(
-                        n_collected = receivers.len(),
-                        "Received acknowledgement from monitor task"
-                    );
-                }
-                Ok(None) => {
-                    tracing::info!(
-                        n_collected = receivers.len(),
-                        "Channel closed, all monitors responded"
-                    );
-                    break;
-                }
-                Err(_) => {
-                    tracing::warn!(
-                        n_collected = receivers.len(),
-                        "Receive timeout expired, moving on with collected responses"
-                    );
-                    break;
-                }
-            }
-        }
-
-        tracing::Span::current().record("n_responses", receivers.len());
-
-        tracing::info!(
-            n_responses = receivers.len(),
-            "Waiting for all acknowledged jobs to complete"
-        );
-
-        if tokio::time::timeout(shutdown_timeout, futures::future::join_all(receivers))
-            .await
+impl ShutdownCoordinator {
+    /// Shut this instance's poller down, in an order that keeps the drain
+    /// honest:
+    ///
+    /// 1. **Stop the poll loop and wait for it to exit.** Nothing new can be
+    ///    claimed or dispatched after this point, so the set of live executions
+    ///    is final. Doing this *before* step 2 is what makes the ack collection
+    ///    complete: `tokio::sync::broadcast` only delivers to receivers that
+    ///    subscribed before `send`, so a generation dispatched after the
+    ///    broadcast would never see the signal, never ack, never be waited
+    ///    for — and would then be force-aborted mid-flight by
+    ///    [`kill_remaining_jobs`], racing its own completion write on the same
+    ///    `Job` aggregate (`ConcurrentModification`, with the loser's execution
+    ///    outcome discarded).
+    /// 2. Broadcast to the monitor tasks and collect their acks.
+    /// 3. Wait for every acked execution to finish.
+    /// 4. Force-reschedule whatever is genuinely still `running`.
+    #[instrument(
+        name = "jobs.perform_shutdown",
+        skip(self),
+        fields(
+            instance_id = %self.instance_id,
+            poll_loop_stopped,
+            broadcast_ok,
+            n_responses
+        )
+    )]
+    async fn perform(&self) -> Result<(), JobError> {
+        if self
+            .shutdown_called
+            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
             .is_err()
         {
-            tracing::warn!("Some jobs did not signal completion within shutdown timeout");
-        } else {
-            tracing::info!("All acknowledged jobs completed");
+            return Ok(());
         }
-    } else {
-        // No active subscribers - wait for the shutdown timeout anyway
-        // to give jobs a chance to complete gracefully
-        tracing::warn!("No active shutdown subscribers, waiting for shutdown timeout");
-        tokio::time::sleep(shutdown_timeout).await;
+
+        let poll_loop_stopped = self.stop_poll_loop().await;
+        tracing::Span::current().record("poll_loop_stopped", poll_loop_stopped);
+
+        let (send, mut recv) = tokio::sync::mpsc::channel::<tokio::sync::oneshot::Receiver<()>>(
+            self.max_jobs_per_process,
+        );
+
+        let broadcast_ok = self.shutdown_tx.send(send).is_ok();
+        tracing::Span::current().record("broadcast_ok", broadcast_ok);
+
+        if broadcast_ok {
+            let mut receivers = Vec::with_capacity(self.max_jobs_per_process);
+            let receive_timeout = Duration::from_millis(100);
+
+            tracing::info!("Starting to collect shutdown acknowledgements from job monitors");
+
+            loop {
+                match tokio::time::timeout(receive_timeout, recv.recv()).await {
+                    Ok(Some(oneshot_rx)) => {
+                        receivers.push(oneshot_rx);
+                        tracing::info!(
+                            n_collected = receivers.len(),
+                            "Received acknowledgement from monitor task"
+                        );
+                    }
+                    Ok(None) => {
+                        tracing::info!(
+                            n_collected = receivers.len(),
+                            "Channel closed, all monitors responded"
+                        );
+                        break;
+                    }
+                    Err(_) => {
+                        tracing::warn!(
+                            n_collected = receivers.len(),
+                            "Receive timeout expired, moving on with collected responses"
+                        );
+                        break;
+                    }
+                }
+            }
+
+            tracing::Span::current().record("n_responses", receivers.len());
+
+            tracing::info!(
+                n_responses = receivers.len(),
+                "Waiting for all acknowledged jobs to complete"
+            );
+
+            if tokio::time::timeout(self.shutdown_timeout, futures::future::join_all(receivers))
+                .await
+                .is_err()
+            {
+                tracing::warn!("Some jobs did not signal completion within shutdown timeout");
+            } else {
+                tracing::info!("All acknowledged jobs completed");
+            }
+        } else {
+            // No subscribers left. With the poll loop already stopped and
+            // drained (step 1) that means there is no live execution to wait
+            // for — every monitor task holds a subscription for as long as its
+            // execution runs — so there is nothing to give a grace period to.
+            tracing::info!("No live job monitors at shutdown, nothing to drain");
+        }
+
+        kill_remaining_jobs(Arc::clone(&self.repo), self.instance_id, self.clock.clone()).await
     }
 
-    kill_remaining_jobs(repo, instance_id, clock).await
+    /// Signal `main_loop` to stop and wait until it has actually exited.
+    ///
+    /// Returns `false` if the loop did not report back within
+    /// `shutdown_timeout` — the shutdown then continues regardless, since
+    /// [`kill_remaining_jobs`] still releases whatever the poller left claimed;
+    /// a wedged poll must not wedge shutdown.
+    ///
+    /// A dropped `poll_exited` sender resolves this immediately: the loop's task
+    /// is gone (aborted with the handle, or panicked), which is as stopped as it
+    /// gets.
+    async fn stop_poll_loop(&self) -> bool {
+        let _ = self.poll_stop_tx.send(true);
+
+        let mut exited_rx = self.poll_exited_rx.clone();
+        let exited = async {
+            loop {
+                let already_exited = *exited_rx.borrow_and_update();
+                if already_exited {
+                    return;
+                }
+                if exited_rx.changed().await.is_err() {
+                    return;
+                }
+            }
+        };
+
+        match tokio::time::timeout(self.shutdown_timeout, exited).await {
+            Ok(()) => {
+                tracing::info!("Poll loop stopped, no further jobs will be dispatched");
+                true
+            }
+            Err(_) => {
+                tracing::warn!(
+                    "Poll loop did not stop within shutdown timeout, continuing shutdown"
+                );
+                false
+            }
+        }
+    }
 }
 
-#[instrument(name = "jobs.kill_remaining_jobs", skip(repo, clock), fields(instance_id = %instance_id, n_killed = tracing::field::Empty))]
+/// Release every execution this instance still holds, and record the forced
+/// reschedule on each `Job`.
+///
+/// The `UPDATE` runs first and inside `op`, so by the time anything is read the
+/// transaction already holds a row lock on every execution it is about to
+/// abort. The entity read then happens **in the same op** (not on a separate
+/// pool connection): every execution-path writer — `complete_job`,
+/// `reschedule_job`, the retry branch of `fail_job` — writes its
+/// `job_executions` row before appending its events, so those locks fence them
+/// out and the version snapshot read here cannot go stale under them.
+///
+/// Writers that touch a `Job` *without* its execution row (`set_result`) are not
+/// fenced by those locks, so each entity write additionally gets its own
+/// `SAVEPOINT`: a lost race rolls back that one row's audit events instead of
+/// failing the whole shutdown, and the release itself — the part that decides
+/// whether the job is schedulable again — is already durable in the same
+/// transaction either way.
+#[instrument(name = "jobs.kill_remaining_jobs", skip(repo, clock), fields(instance_id = %instance_id, n_killed = tracing::field::Empty, n_conflicts = tracing::field::Empty))]
 async fn kill_remaining_jobs(
     repo: Arc<JobRepo>,
     instance_id: uuid::Uuid,
@@ -1330,8 +1423,10 @@ async fn kill_remaining_jobs(
         .collect();
 
     let ids: Vec<JobId> = attempt_map.keys().copied().collect();
-    let entities = repo.find_all::<crate::Job>(&ids).await?;
+    let entities: std::collections::HashMap<JobId, crate::Job> =
+        repo.find_all_in_op(&mut op, &ids).await?;
 
+    let mut n_conflicts = 0usize;
     for (job_id, mut job) in entities {
         let attempt_index = attempt_map[&job_id];
 
@@ -1343,8 +1438,24 @@ async fn kill_remaining_jobs(
         );
 
         job.abort_execution("killed job".to_string(), now, attempt_index);
-        repo.update_in_op(&mut op, &mut job).await?;
+        if let Err(e) = op
+            .with_savepoint(async |sp| repo.update_in_op(sp, &mut job).await)
+            .await?
+        {
+            // The row is released regardless (that write is outside this
+            // savepoint), so the job stays schedulable; only its abort audit
+            // trail is missing.
+            n_conflicts += 1;
+            tracing::warn!(
+                job_id = %job_id,
+                attempt = attempt_index,
+                exception.message = %e,
+                exception.type = std::any::type_name_of_val(&e),
+                "Could not record forced reschedule; execution row released anyway"
+            );
+        }
     }
+    tracing::Span::current().record("n_conflicts", n_conflicts);
     op.commit().await?;
     Ok(())
 }
@@ -1356,6 +1467,117 @@ mod tests {
     async fn init_pool() -> anyhow::Result<PgPool> {
         let pg_con = std::env::var("PG_CON").unwrap();
         Ok(sqlx::PgPool::connect(&pg_con).await?)
+    }
+
+    /// Seed a real `Job` aggregate (events and all) plus a `running` execution
+    /// row owned by `instance_id` — what a live execution looks like to
+    /// [`kill_remaining_jobs`].
+    async fn seed_running_entity(
+        pool: &PgPool,
+        repo: &JobRepo,
+        job_type: &str,
+        instance_id: uuid::Uuid,
+    ) -> anyhow::Result<JobId> {
+        let id = JobId::new();
+        let new_job = crate::entity::NewJob::builder()
+            .id(id)
+            .job_type(JobType::from_owned(job_type.to_string()))
+            .config(serde_json::json!({}))?
+            .build()
+            .expect("build NewJob");
+        repo.create(new_job).await?;
+
+        let now = chrono::Utc::now();
+        sqlx::query(
+            "INSERT INTO job_executions \
+             (id, job_type, state, poller_instance_id, attempt_index, alive_at, created_at) \
+             VALUES ($1, $2, 'running', $3, 1, $4, $4)",
+        )
+        .bind(uuid::Uuid::from(id))
+        .bind(job_type)
+        .bind(instance_id)
+        .bind(now)
+        .execute(pool)
+        .await?;
+        Ok(id)
+    }
+
+    /// Block until some backend on this database is waiting on a lock.
+    ///
+    /// The synchronisation point for the test below: it makes the interleaving
+    /// an observed fact rather than a timing assumption — no sleeping until the
+    /// race "probably" happened.
+    async fn wait_for_blocked_backend(pool: &PgPool) -> anyhow::Result<()> {
+        for _ in 0..600 {
+            let blocked: i64 = sqlx::query_scalar(
+                "SELECT count(*) FROM pg_stat_activity \
+                 WHERE datname = current_database() AND wait_event_type = 'Lock'",
+            )
+            .fetch_one(pool)
+            .await?;
+            if blocked > 0 {
+                return Ok(());
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        anyhow::bail!("no backend ever blocked on a lock");
+    }
+
+    /// `kill_remaining_jobs` must survive losing a version race on a `Job` it is
+    /// force-rescheduling — the failure lana PR #8282 saw escape
+    /// `Jobs::shutdown()` as `JobModifyError - ConcurrentModification`.
+    ///
+    /// The concurrent writer here has `set_result`'s shape: it appends to the
+    /// `Job` without touching the execution row, so the row locks
+    /// `kill_remaining_jobs` holds do not fence it out. It claims the entity's
+    /// next event sequence first and commits while the kill is mid-flight, so
+    /// the kill's own append is the one that collides.
+    ///
+    /// Releasing the execution row is what must survive: the job has to stay
+    /// schedulable, and shutdown must not fail because one audit append lost a
+    /// race.
+    #[tokio::test]
+    async fn kill_remaining_jobs_survives_losing_a_concurrent_entity_write() -> anyhow::Result<()> {
+        let pool = init_pool().await?;
+        let repo = Arc::new(JobRepo::new(&pool));
+        let clock = ClockHandle::realtime();
+        let instance_id = uuid::Uuid::now_v7();
+        let job_type = format!("kill-race-{}", uuid::Uuid::now_v7());
+
+        let id = seed_running_entity(&pool, &repo, &job_type, instance_id).await?;
+
+        // The competing writer: entity append staged, not yet committed, so it
+        // owns the next event sequence.
+        let mut writer_op = repo.begin_op_with_clock(&clock).await?;
+        let mut job = repo.find_by_id_in_op(&mut writer_op, id).await?;
+        let return_value = crate::outcome::JobReturnValue::try_from(&"progress")?;
+        assert!(job.update_return_value(return_value).did_execute());
+        repo.update_in_op(&mut writer_op, &mut job).await?;
+
+        // The kill blocks on that staged sequence...
+        let kill = tokio::spawn(kill_remaining_jobs(
+            Arc::clone(&repo),
+            instance_id,
+            clock.clone(),
+        ));
+        wait_for_blocked_backend(&pool).await?;
+
+        // ...and only now does the competing write become the winner.
+        writer_op.commit().await?;
+
+        kill.await?
+            .expect("shutdown must not fail because a forced-reschedule append lost a race");
+
+        let row: (String, Option<uuid::Uuid>) = sqlx::query_as(
+            "SELECT state::text, poller_instance_id FROM job_executions WHERE id = $1",
+        )
+        .bind(uuid::Uuid::from(id))
+        .fetch_one(&pool)
+        .await?;
+        assert_eq!(row.0, "pending", "execution must be released for reclaim");
+        assert_eq!(row.1, None, "released execution must not stay owned");
+
+        Ok(())
     }
 
     async fn seed_running_job(

--- a/tests/shutdown_drain.rs
+++ b/tests/shutdown_drain.rs
@@ -1,0 +1,198 @@
+//! `Jobs::shutdown()` must fully drain: once it returns, no execution of this
+//! instance may still be running, and none may have been force-aborted
+//! mid-flight.
+//!
+//! The hazard is the poll loop, not the monitors. A `poll_and_dispatch()` in
+//! flight when shutdown starts used to keep claiming and dispatching rows; a
+//! generation created that late subscribes to the shutdown broadcast *after*
+//! the `send`, and `tokio::sync::broadcast` never delivers to late subscribers
+//! — so it never acked, was never waited for, and got force-aborted by
+//! `kill_remaining_jobs` while its future was still live. Both writes then
+//! landed on the same `Job` aggregate and one of them lost with
+//! `ConcurrentModification`: either the execution's own completion (its work
+//! silently discarded) or the kill itself (the error escaping
+//! `Jobs::shutdown()`, as seen in lana PR #8282).
+//!
+//! Self-rescheduling jobs make that window easy to hit: they hand a row back to
+//! `pending` and notify, so the loop is polling essentially continuously.
+
+use async_trait::async_trait;
+use job::{
+    CurrentJob, Job, JobCompletion, JobId, JobInitializer, JobPollerConfig, JobRunner, JobSpawner,
+    JobSvcConfig, JobType, Jobs,
+};
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::time::Duration;
+
+/// Shared with the runners so they can report work done after `shutdown()`
+/// already returned.
+#[derive(Default)]
+struct DrainWatch {
+    shutdown_returned: AtomicBool,
+    ran_after_shutdown: AtomicUsize,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct ChurnConfig;
+
+struct ChurnInitializer {
+    job_type: JobType,
+    watch: Arc<DrainWatch>,
+}
+
+impl JobInitializer for ChurnInitializer {
+    type Config = ChurnConfig;
+
+    fn job_type(&self) -> JobType {
+        self.job_type.clone()
+    }
+
+    fn init(
+        &self,
+        _job: &Job,
+        _: JobSpawner<Self::Config>,
+    ) -> Result<Box<dyn JobRunner>, Box<dyn std::error::Error>> {
+        Ok(Box::new(ChurnRunner {
+            watch: Arc::clone(&self.watch),
+        }))
+    }
+}
+
+struct ChurnRunner {
+    watch: Arc<DrainWatch>,
+}
+
+#[async_trait]
+impl JobRunner for ChurnRunner {
+    async fn run(
+        &self,
+        current_job: CurrentJob,
+    ) -> Result<JobCompletion, Box<dyn std::error::Error>> {
+        // `set_result` is an ordinary entity write that does NOT touch the
+        // `job_executions` row, so it is not serialized behind the row locks
+        // `kill_remaining_jobs` holds — it is the write that collides.
+        for i in 0..8u32 {
+            current_job.set_result(&i).await?;
+            if self.watch.shutdown_returned.load(Ordering::SeqCst) {
+                self.watch.ran_after_shutdown.fetch_add(1, Ordering::SeqCst);
+            }
+        }
+        Ok(JobCompletion::RescheduleNow)
+    }
+}
+
+/// Shutting down under continuous self-rescheduling churn must leave nothing
+/// running, abort nothing mid-flight, and return `Ok`.
+///
+/// Before the poll loop was stopped and drained ahead of the monitor broadcast,
+/// each iteration force-aborted roughly half of the live executions
+/// (`aborted_events` 18-22 of 40) and logged one `ConcurrentModification` per
+/// aborted generation.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn shutdown_drains_self_rescheduling_jobs() -> anyhow::Result<()> {
+    let pg_con = std::env::var("PG_CON").unwrap();
+    // Every job holds a connection for its own writes, so this pool is sized
+    // for the whole churn set rather than taking the shared test default.
+    let pool = sqlx::postgres::PgPoolOptions::new()
+        .max_connections(25)
+        .connect(&pg_con)
+        .await?;
+
+    const N_JOBS: usize = 20;
+
+    for iteration in 0..5u32 {
+        let watch = Arc::new(DrainWatch::default());
+
+        let config = JobSvcConfig::builder()
+            .pool(pool.clone())
+            .poller_config(JobPollerConfig {
+                // Poll as fast as the churn allows: the tighter the cadence,
+                // the likelier a poll is in flight when shutdown starts.
+                poll_debounce: Duration::from_millis(1),
+                ..Default::default()
+            })
+            .build()
+            .expect("build JobSvcConfig");
+
+        let mut jobs = Jobs::init(config).await?;
+        // Unique per iteration: rows left pending by an earlier iteration (or
+        // an earlier run) must not be re-claimed here.
+        let job_type = JobType::new(Box::leak(
+            format!("shutdown-drain-{}", uuid::Uuid::now_v7()).into_boxed_str(),
+        ));
+        let spawner = jobs.add_initializer(ChurnInitializer {
+            job_type,
+            watch: Arc::clone(&watch),
+        });
+        jobs.start_poll().await?;
+
+        let mut ids = Vec::with_capacity(N_JOBS);
+        for _ in 0..N_JOBS {
+            let id = JobId::new();
+            spawner.spawn(id, ChurnConfig).await?;
+            ids.push(uuid::Uuid::from(id));
+        }
+
+        // Let the churn reach a steady state, so the poll loop is busy rather
+        // than parked when shutdown starts.
+        tokio::time::sleep(Duration::from_millis(300)).await;
+
+        jobs.shutdown()
+            .await
+            .unwrap_or_else(|e| panic!("iteration {iteration}: shutdown failed: {e}"));
+        watch.shutdown_returned.store(true, Ordering::SeqCst);
+
+        let still_running: i64 = sqlx::query_scalar(
+            "SELECT count(*) FROM job_executions WHERE id = ANY($1) AND state = 'running'",
+        )
+        .bind(&ids)
+        .fetch_one(&pool)
+        .await?;
+        assert_eq!(
+            still_running, 0,
+            "iteration {iteration}: executions left running after shutdown"
+        );
+
+        // A forced abort means the drain missed a live execution: every
+        // generation should have acked and finished on its own.
+        let aborted: i64 = sqlx::query_scalar(
+            "SELECT count(*) FROM job_events \
+             WHERE id = ANY($1) AND event->>'type' = 'execution_aborted'",
+        )
+        .bind(&ids)
+        .fetch_one(&pool)
+        .await?;
+        assert_eq!(
+            aborted, 0,
+            "iteration {iteration}: {aborted} execution(s) were force-aborted mid-flight \
+             instead of being drained"
+        );
+
+        // Any work observed after `shutdown()` returned means an execution
+        // outlived the shutdown it was supposed to be waited for.
+        let events_at_return: i64 =
+            sqlx::query_scalar("SELECT count(*) FROM job_events WHERE id = ANY($1)")
+                .bind(&ids)
+                .fetch_one(&pool)
+                .await?;
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        let events_after: i64 =
+            sqlx::query_scalar("SELECT count(*) FROM job_events WHERE id = ANY($1)")
+                .bind(&ids)
+                .fetch_one(&pool)
+                .await?;
+        assert_eq!(
+            events_at_return, events_after,
+            "iteration {iteration}: job events kept being written after shutdown returned"
+        );
+        assert_eq!(
+            watch.ran_after_shutdown.load(Ordering::SeqCst),
+            0,
+            "iteration {iteration}: a job runner was still executing after shutdown returned"
+        );
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Fixes a shutdown race in the poller, root-caused in [`handoff-shutdown-kill-remaining-jobs-race.md`](https://raw.githubusercontent.com/GaloyMoney/drua-library/main/spaces/job-dev/handoff-shutdown-kill-remaining-jobs-race.md) (drua library space `job-dev`) from a lana-bank PR #8282 CI failure. Draft — validation evidence below, not marked ready for review.

`Jobs::shutdown()` broadcast to the job monitors while the poll loop was still claiming and dispatching rows. A generation dispatched after that `send` subscribes too late to ever receive it (`tokio::sync::broadcast` only delivers to prior subscribers), so it never acked and was never waited for — and `kill_remaining_jobs` then force-aborted it while its future was still live. Both writes land on the same `Job` aggregate and one loses with `ConcurrentModification`.

## Validation before fixing

Per instruction, the bug was reproduced in this repo before any code was written.

**Direction 1 — loser is the execution** (new harness, 40 self-rescheduling jobs, `poll_debounce` 1ms, 10 iterations, live PG): **18–22 of 40** execution rows were still `state='running'` when `kill_remaining_jobs` ran, i.e. *after* `perform_shutdown` logged `All acknowledged jobs completed`. With `RUST_LOG=warn`, every shutdown produced 20× `Job still running after shutdown timeout, forcing reschedule` immediately followed by 20× `job dispatcher error … JobModifyError - ConcurrentModification`. Those executions' completion writes — including any `set_result` output — were discarded.

**Direction 2 — loser is the kill** (what lana #8282 saw escape `Jobs::shutdown()`): constructed deterministically, gated on `pg_stat_activity` rather than a sleep. Pre-fix it returns `Modify(ConcurrentModification)`; post-fix it returns `Ok` with the execution row released.

## Root cause

- `src/poller.rs:195-204` (pre-fix) — `main_loop` only checked the shutdown broadcast *between* `poll_and_dispatch()` calls. The `shutdown_called` `AtomicBool` (`:78,148,1227`) existed but was never read by the poller: it only made `perform_shutdown` idempotent. **Invariant violated:** after shutdown is requested, no new execution may be dispatched.
- `src/poller.rs:1303-1348` (pre-fix) — `kill_remaining_jobs` row-locked the executions in its op, then read the entities with `repo.find_all` on a *separate pool connection*, then blind-wrote abort events for all of them in one transaction with no fence. **Invariant violated:** a versioned write must not be issued from a snapshot read outside the transaction that writes it.

## Fix

1. Shutdown stops the poll loop and **waits for it to exit** before signalling the monitors, so the set of live executions is final and each is subscribed in time to ack. An in-flight poll is left intact, so rows it already claimed are still dispatched rather than stranded in `state='running'`. The stop is a `watch` (latching), not a broadcast, so a poll in flight when it lands still observes it. Bounded by `shutdown_timeout`, so a wedged poll cannot wedge shutdown.
2. `kill_remaining_jobs` hardened for what it still legitimately handles: entity read moved **inside** the op that holds the row locks (execution-path writers write their row before their events, so those locks now fence them out), and each entity write gets its own `SAVEPOINT` (es-entity 0.12.8, per #166) — a lost race costs that row's audit trail instead of failing the whole shutdown, while the release stays durable.

Rejected: gating per-row dispatch on a shared `shutdown_called` (handoff option 1). It leaves rows claimed-but-never-dispatched stuck `running` until the lost-handler reclaims them — `job_lost_interval`, 5 min by default — i.e. a multi-minute stall after every restart, and a late generation still misses the broadcast.

## Tests

Both fail pre-fix, pass post-fix, no sleep-based synchronisation:

- `tests/shutdown_drain.rs::shutdown_drains_self_rescheduling_jobs` — asserts nothing left `running`, zero `execution_aborted` events, and no runner or event write after `shutdown()` returned. Pre-fix: **19 of 20 force-aborted** on iteration 0.
- `src/poller.rs::tests::kill_remaining_jobs_survives_losing_a_concurrent_entity_write` — deterministic, `pg_stat_activity`-gated. Pre-fix: `Modify(ConcurrentModification)`.

Full suite green (109 tests, live PG), `nix flake check` passes fresh. New tests stable over 5 consecutive runs.

## Downstream

`poller.rs`-internal only, no public API change → patch release. Consumers (obix, cala, lana) get a `Jobs::shutdown()` that may take up to one extra poll cycle and actually drains; the "no live monitors" path is now fast instead of sleeping the full `shutdown_timeout`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes ordered shutdown, job claiming, and forced reschedule logic on the critical path; mistakes could strand jobs or lose execution outcomes, though new integration and lock-gated tests target the reported race.
> 
> **Overview**
> Fixes a shutdown race where `Jobs::shutdown()` could broadcast to job monitors while the poll loop still claimed and dispatched work. Late-dispatched executions never received the broadcast ack path, were force-aborted by `kill_remaining_jobs` mid-flight, and collided on the same `Job` aggregate (`ConcurrentModification`).
> 
> **Shutdown ordering** is centralized in a new `ShutdownCoordinator` (shared by explicit `shutdown` and handle drop). Shutdown now **stops the poll loop via a latching `watch`**, waits until `main_loop` exits (bounded by `shutdown_timeout`), then broadcasts to monitors, waits for acked executions, and only then runs `kill_remaining_jobs`. In-flight polls still finish dispatching rows already claimed so nothing stays stuck `running`.
> 
> **`kill_remaining_jobs`** reads `Job` entities inside the same transaction that locks execution rows, and wraps per-job audit updates in **SAVEPOINTs** so a lost version race releases the execution row but does not fail shutdown. The no-monitor path no longer sleeps the full timeout when the poll loop is already drained.
> 
> Adds **`tests/shutdown_drain.rs`** (churn under self-rescheduling jobs) and a **`pg_stat_activity`-gated** unit test for concurrent entity writes during kill.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0381f75ffd8d662649d37c79e3630ebd4bbee672. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->