### PR TITLE
test: fix two flakes — a shared job type and a racy state snapshot

### DIFF
--- a/tests/batched_job.rs
+++ b/tests/batched_job.rs
@@ -444,7 +444,16 @@ async fn batch_error_retries_every_item_and_retries_run_alone() -> anyhow::Resul
 
     let log = Arc::new(Mutex::new(AttemptLog::default()));
     let spawner = jobs.add_batched_initializer(FailFirstInitializer {
-        job_type: JobType::new("batched-fail-first"),
+        // Process-unique, unlike most types in this file. This test is the
+        // one that asserts on the shape of EVERY batch its type produces, so
+        // any row of the type left behind by an earlier run against the same
+        // persistent dev database gets claimed by this run's poller and shows
+        // up as an extra batch (observed as `saw [1, 1, 5, 1, ...]`, the two
+        // leading singletons being ids this test never spawned). Ordinary
+        // tests only assert on their own ids and so tolerate the sharing.
+        job_type: JobType::new(Box::leak(
+            format!("batched-fail-first-{}", uuid::Uuid::now_v7()).into_boxed_str(),
+        )),
         log: Arc::clone(&log),
     });
 

--- a/tests/parked_rows.rs
+++ b/tests/parked_rows.rs
@@ -542,10 +542,7 @@ async fn spawn_yields_to_an_older_pending_row_of_the_same_type() -> anyhow::Resu
     let new_id = JobId::new();
     spawner.spawn(new_id, Cfg).await?;
 
-    // Read both rows in ONE query so the background poll loop gets no
-    // window to independently claim `new_id` between two separate reads,
-    // which would be a legitimate claim (once `old_id` is running) rather
-    // than a fairness violation, but would still make this assertion racy.
+    // Read both rows in ONE query so the two states come from one snapshot.
     let (old_state, new_state): (String, String) = sqlx::query_as(
         "SELECT \
            (SELECT state::text FROM job_executions WHERE id = $1), \
@@ -555,13 +552,27 @@ async fn spawn_yields_to_an_older_pending_row_of_the_same_type() -> anyhow::Resu
     .bind(uuid::Uuid::from(new_id))
     .fetch_one(&pool)
     .await?;
+    // `old_state` carries the whole fairness claim, and carries it on its
+    // own: the spawn's transaction claims exactly one unit for the one row
+    // it added, and this asserts that the unit went to the OLDER row rather
+    // than to `new_id`. The violation this guards against -- the spawn
+    // dispatching itself past older backlog -- necessarily leaves `old_id`
+    // `pending`, so it cannot hide behind a passing assertion here.
+    //
+    // What is deliberately NOT asserted is `new_state == "pending"`. That
+    // used to be here and was the source of this test's flakiness, without
+    // fairness ever having broken: having correctly claimed the older row,
+    // the spawn's commit legitimately emits `execution_ready` for the type
+    // (`new_id` was added and NOT claimed), the poll loop wakes on it, and
+    // claims `new_id` on a later pass. Both rows end up `running` and the
+    // old assertion read red on a system that did exactly the right thing.
+    // Capping the type's concurrency does not close the window either --
+    // units are counted at DISPATCH, after the claiming transaction commits,
+    // so a poll landing in between still sees a free slot.
     assert_eq!(
         old_state, "running",
-        "the OLDER due row must be the one claimed"
-    );
-    assert_eq!(
-        new_state, "pending",
-        "a fresh spawn must not cut ahead of older same-type backlog"
+        "the OLDER due row must be the one the spawn's own claim served \
+         (new_id is {new_state})"
     );
 
     Ok(())


### PR DESCRIPTION
Two local-suite flakes, root-caused and fixed. Neither reproduces on CI (fresh database, lighter contention), and neither is a regression from #177 — I measured both at identical rates on `c393897` (pre-#177) and `1a801db` over 15 full-suite runs each.

## 1. `batch_error_retries_every_item_and_retries_run_alone` — shared job type

The type was the hardcoded `batched-fail-first`, shared by every run against the same persistent dev database. This is the one test that asserts on the shape of **every** batch its type produces, so any row left behind by an earlier run gets claimed by the next run's poller and shows up as an extra batch.

Instrumenting the runner with per-item ids and attempts showed it directly:

```
DIAG batch: [("6b860d41857f", 2)]      <- not this test's job
DIAG batch: [("6b9338efdf12", 2)]      <- not this test's job
DIAG batch: [("044f…", 1), ("0459…", 1), ("0463…", 1), ("0479…", 1), ("048a…", 1)]
DIAG batch: [("044f…", 2)] … (the five real retries)
retry batches must contain exactly one job, saw [1, 1, 5, 1, 1, 1, 1, 1]
```

The two leading singletons carry ids this test never spawned, at attempt 2 — alongside 255 accumulated `jobs` rows for the type. Fixed by making the type process-unique, like the ones in `parked_rows.rs`/`lock_ordering.rs`. Ordinary tests only assert on their own ids and so tolerate the sharing; this one cannot.

## 2. `spawn_yields_to_an_older_pending_row_of_the_same_type` — racy snapshot

It asserted both `old == running` **and** `new == pending` from a snapshot taken after the spawn returned. The second half was never sound: having correctly claimed the older row, the spawn's commit legitimately emits `execution_ready` for the type (the new row was added and NOT claimed), the poll loop wakes on it and claims the new row on a later pass. Both rows end up `running` and the assertion reads red on a system that did exactly the right thing.

Confirmed by capturing the failure — `left: "running", right: "pending"` on `new_state`, with `old_state == running` passing.

Capping the type's concurrency does **not** close the window: units are counted at DISPATCH, after the claiming transaction commits, so a poll landing in between still sees a free slot. Verified — with a cap of 1 and a blocking runner, both rows still went `running`.

Kept the assertion that carries the actual fairness claim (the spawn's one claimed unit went to the older row) and documented why the other half is gone. A genuine violation still can't hide: dispatching itself past older backlog necessarily leaves `old_id` pending.

## Result

**24 consecutive full-suite runs, one failure** — against a baseline where `batch_error_retries` alone failed 13 of 15.

## Left unfixed on purpose: a real missed-wake

That one residual failure is a **different and genuine defect**, not a test artifact, so I did not paper over it:

A batched type whose in-flight units exhaust its cap is dropped from `plan_claim`, so the poll loop sleeps `MAX_WAIT` (60s) and relies on `tracker.batch_completed` to wake it. That wake is a `Notify::notify_one()`, which holds at most one permit — so a permit consumed by a poll that runs *before* the retry rows' 10–50ms backoff elapses can leave due rows unclaimed for the full 60s.

Captured directly: two rows `pending`, attempt 2, past their `execute_at`, unowned, while the test's 30s `await_all` budget expired.

That deserves its own change to the poller's wake accounting, and I'd rather propose it separately than bury it in a test-cleanup PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only assertion and job-type isolation changes; no production code or scheduling logic is modified.
> 
> **Overview**
> Fixes two local-suite flakes without changing production behavior.
> 
> `batch_error_retries_every_item_and_retries_run_alone` now uses a process-unique job type so leftover rows from a persistent dev DB cannot be claimed and inflate batch-size assertions. Other tests in the file still share types because they only check their own ids.
> 
> `spawn_yields_to_an_older_pending_row_of_the_same_type` now only asserts that the spawn’s claim went to the older row. It no longer requires the new row to stay `pending`, which raced a legitimate poller claim after `execution_ready`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3befe275f5ccc75646d8a94760a2f7912a07564f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->