### PR TITLE
perf(poller): pin enable_seqscan=off on the poll pool — generic plan falls back to per-type heap scans

### DIFF
--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -151,13 +151,24 @@ by the backlog.
 ### Ordered index access is mandatory
 
 The claim query runs on a dedicated two-connection pool (`build_poll_pool`)
-whose connections carry `plan_cache_mode = force_generic_plan` and
-`enable_bitmapscan = off` from `after_connect`.
+whose connections carry `plan_cache_mode = force_generic_plan`,
+`enable_bitmapscan = off`, and `enable_seqscan = off` from `after_connect`.
 
 - **`enable_bitmapscan = off`** is not a micro-optimisation. A bitmap scan
   returns rows in heap order, destroying the index ordering the prefix scan
   depends on and forcing a sort of every candidate: **10.3 ms vs 1.4 ms** on
   identical data.
+- **`enable_seqscan = off`** closes the other escape hatch. Under a generic
+  plan built while `job_executions` stats read near-empty, index bloat
+  inflates the pending index's cost estimate enough that the planner prefers
+  a heap scan for each of the poll's per-type LATERAL probes — one seq scan
+  of the whole (churn-bloated) heap per registered type, ~57 per poll on a
+  registry this crate's size. That is the entire backlog-independent poll
+  floor: **3,192 -> 59 shared blocks/call** measured idle on a bench replaying
+  production churn, with the pin at parity (within 1%) in every claiming
+  regime (backlog / spin / storm). REINDEX-only mitigation decays back to the
+  unpinned floor within hours of further churn; the pin is immune to bloat by
+  construction. (sb-max9 evidence, 2026-08-21.)
 - **A dedicated pool, not `SET LOCAL`.** Session-level overrides must never
   leak onto the shared application pool, and setting them once per connection
   instead of inside a `BEGIN`/`COMMIT` on every poll turns the claim into a

--- a/src/poller.rs
+++ b/src/poller.rs
@@ -77,13 +77,24 @@ pub(crate) struct JobPoller {
 }
 
 /// A tiny dedicated pool for [`poll_jobs`], reusing the main pool's connect
-/// options. The claim query needs `plan_cache_mode = force_generic_plan` and
-/// `enable_bitmapscan = off` (see PERFORMANCE.md, "Ordered index access is
-/// mandatory") on every connection it runs on; setting them once per
-/// connection here — instead of `SET LOCAL` inside a `BEGIN`/`COMMIT` on every
-/// poll — turns the claim into a single autocommit statement (5 round trips
-/// down to 1) without ever touching a connection the application pool might
-/// hand to unrelated queries.
+/// options. The claim query needs `plan_cache_mode = force_generic_plan`,
+/// `enable_bitmapscan = off`, and `enable_seqscan = off` (see
+/// PERFORMANCE.md, "Ordered index access is mandatory") on every connection
+/// it runs on; setting them once per connection here — instead of `SET
+/// LOCAL` inside a `BEGIN`/`COMMIT` on every poll — turns the claim into a
+/// single autocommit statement (5 round trips down to 1) without ever
+/// touching a connection the application pool might hand to unrelated
+/// queries.
+///
+/// `enable_seqscan = off` completes the same contract as `enable_bitmapscan
+/// = off`: under a generic plan built while table stats read near-empty,
+/// the planner otherwise falls back to one heap seq scan per type probe
+/// (~57 per poll on a registry this crate's size) because index bloat
+/// inflates the index path's cost estimate. Forcing ordered index access
+/// keeps the poll's cost O(claimed) + O(registered types), independent of
+/// heap and index bloat. Measured: idle poll 3,192 -> 59 shared
+/// blocks/call; no regression in any claiming regime (sb-max9 evidence,
+/// 2026-08-21).
 async fn build_poll_pool(main_pool: &PgPool) -> Result<PgPool, sqlx::Error> {
     let options: PgConnectOptions = (*main_pool.connect_options()).clone();
     PgPoolOptions::new()
@@ -94,6 +105,9 @@ async fn build_poll_pool(main_pool: &PgPool) -> Result<PgPool, sqlx::Error> {
                     .execute(&mut *conn)
                     .await?;
                 sqlx::query("SET enable_bitmapscan = off")
+                    .execute(&mut *conn)
+                    .await?;
+                sqlx::query("SET enable_seqscan = off")
                     .execute(&mut *conn)
                     .await?;
                 Ok(())

--- a/tests/poll_pool_plan.rs
+++ b/tests/poll_pool_plan.rs
@@ -1,0 +1,69 @@
+//! Regression for `build_poll_pool`'s `enable_seqscan = off` pin
+//! (src/poller.rs).
+//!
+//! Under `plan_cache_mode = force_generic_plan`, a per-type claim probe can
+//! fall back to a full heap seq scan when the planner's cost estimate for
+//! the pending index is inflated (bloat, or stats reading near-empty) —
+//! measured on sb-max9 as the dominant cost of the poll's backlog-independent
+//! floor (idle poll: 3,192 -> 59 shared blocks/call with the pin). This test
+//! only asserts the *plan shape* the pin buys: no seq scan of
+//! `job_executions` under the exact GUCs `build_poll_pool` sets. It does not
+//! reproduce the bloat/near-empty-stats trigger condition itself (that needs
+//! a churned substrate; see the sb-max9 evidence report for the full bench).
+//!
+//! Deliberately narrow: it probes a minimal query shaped like one iteration
+//! of the poll's `window_rows` LATERAL (not the full multi-CTE poll
+//! statement, which is private to `poller.rs`), so it isn't coupled to the
+//! poll query's exact text and won't break on unrelated poll-query edits.
+
+mod helpers;
+
+#[tokio::test]
+async fn poll_pool_guards_against_seq_scan() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let mut conn = pool.acquire().await?;
+
+    // Mirror `build_poll_pool`'s `after_connect` GUCs exactly.
+    sqlx::query("SET plan_cache_mode = force_generic_plan")
+        .execute(&mut *conn)
+        .await?;
+    sqlx::query("SET enable_bitmapscan = off")
+        .execute(&mut *conn)
+        .await?;
+    sqlx::query("SET enable_seqscan = off")
+        .execute(&mut *conn)
+        .await?;
+
+    // Shape of one `window_rows` LATERAL iteration: a per-type prefix probe
+    // against the pending-claim index (`idx_job_executions_pending_execute_at`,
+    // leading column `job_type`).
+    let rows: Vec<(String,)> = sqlx::query_as(
+        r#"
+        EXPLAIN (FORMAT TEXT)
+        SELECT je.id::text
+        FROM job_executions je
+        WHERE je.state = 'pending'
+          AND je.job_type = $1
+          AND je.execute_at <= now()
+        ORDER BY je.execute_at, je.id
+        LIMIT 60
+        "#,
+    )
+    .bind("nonexistent.bench.probe-type")
+    .fetch_all(&mut *conn)
+    .await?;
+
+    let plan: String = rows
+        .into_iter()
+        .map(|(line,)| line)
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(
+        !plan.contains("Seq Scan on job_executions"),
+        "poll-pool GUCs (force_generic_plan + enable_bitmapscan=off + enable_seqscan=off) \
+         should force ordered index access on job_executions, but the plan fell back to a \
+         heap seq scan:\n{plan}"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
## What

Pins `enable_seqscan = off` on the dedicated poll pool (`build_poll_pool`), alongside the existing `plan_cache_mode = force_generic_plan` and `enable_bitmapscan = off`.

## Why

sb-max9 (production stress run, job 0.13.3) found the claim poll was the **#1 statement in the workload** — 48.00 of 118.16 ms/loan at step 1 — with a cost floor independent of backlog (paid even with zero due jobs).

Root cause, confirmed with local `EXPLAIN (ANALYZE, BUFFERS)` under production's exact GUCs: under `force_generic_plan`, when `job_executions` stats read near-empty and the pending index is churn-bloated, the planner prices the bloated index above a heap scan and plans **each of the poll's ~57 per-type LATERAL probes as a full seq scan of the heap** (`Seq Scan … loops=57`). This is the mechanism behind the "expensive when idle, cheap when claiming" pattern sb-max9 observed — it's a plan choice, not raw bloat reads.

`enable_seqscan = off` closes this escape hatch, completing the "ordered index access is mandatory" contract `enable_bitmapscan = off` already established for the same pool.

## Evidence

Local bench replaying sb-max9's churn history (57 registered types, 500k spawn/claim/complete cycles, production-cadence autovacuum, converged to within ~2x of live table/index sizes), exact poll query extracted from `src/poller.rs`, prepared under the production GUCs, median of 5 post-warmup `EXPLAIN (ANALYZE, BUFFERS)` reps (shared blocks/call, deterministic across reps):

| Regime | baseline | + `enable_seqscan=off` |
|---|---|---|
| Idle (0 due) | 3,192 | **59** (−98.2%) |
| Spin (450 backlog, hot type capped) | 688 | 646 |
| Full-claim (450 due, claims 170) | 5,323 | 5,286 |
| Storm (9,350 due, claims 170) | 50,536 | 50,402 |

**Reproduction gate:** production's live idle floor was independently re-measured on the still-running sb-max9 environment via `pg_stat_statements` deltas at zero due jobs: **3,417–4,803 blks/call** — the local bench reproduced this at 3,192 before the pin.

**Durability:** an alternative mitigation (`REINDEX`) was measured to buy the same win but decay back to the exact unpinned floor within ~100k further churn cycles (~2.5h at step-1 rates). This pin changes plan *choice*, not index shape, so it's immune to bloat regrowth by construction.

**Head-to-head vs the 0.12.1 "fat poll":** also measured (same substrate, each design's own index set). 0.13.x+this pin is at or below the fat poll in every regime, and 3–4 orders of magnitude cheaper in the blocked-queue-storm regime the parked-row redesign exists for (255,684 vs 59 blks/call) — the regime sb-max9 actually produced (parked spiked to 76,486 while running stayed ≤94).

Full report, raw `EXPLAIN` output, bench harness, and the corrected mechanism analysis (the originating handoff attributed the floor to raw index-bloat reads rather than a plan flip) are available on request — kept out of this repo per the research task's constraints.

## Risk

Change is scoped to the 2-connection dedicated poll pool only — the main application pool is untouched, and no query text changes. In every measured regime `enable_seqscan=off` was at parity (within 1%) with the current behavior; it only matters in the idle/near-empty-stats case where it removes the seq-scan fallback entirely.

## Validation still open

Local bench ran vanilla PostgreSQL 18.1; production is AlloyDB PG 18.3, and the stress environment's read-only role blocked a direct `EXPLAIN` of the production generic plan (same gap noted in the originating handoff). Falsifiable criteria for the next stress run:

- Step-1 poll ≤ 34 ms/loan (10% below the 0.12.1 fat-poll baseline) — expected **2–5 ms/loan** (was 48.00 on 0.13.3)
- Job-crate total ≤ 104 ms/loan — expected **72–75** (fat-poll baseline: 115.6)
- Poll blocks/call in quiet settle should collapse from ~3,656 to double digits

If the pin underdelivers on AlloyDB, the measured fallback is a presence-check-first poll rewrite (idle: 110 blks/call; not implemented here — larger change, higher review cost, dominated by this pin on cost in every regime tested).

## Tests

- New: `tests/poll_pool_plan.rs` — connects with the pool's exact GUCs, `EXPLAIN`s a minimal per-type probe shaped like one `window_rows` LATERAL iteration, asserts no `Seq Scan on job_executions` node. Deliberately narrow — doesn't attempt to reproduce the bloat/near-empty-stats trigger itself.
- Full suite: 159/159 passing.
- `nix flake check --option eval-cache false`: all checks passed (fmt, clippy, deny, audit — confirmed genuine rebuild, not a cache hit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Planner GUC on the claim path can change query plans if an index is missing or unusable; scope is limited to the dedicated 2-connection poll pool and measured claiming regimes stayed at parity.
> 
> **Overview**
> Pins `enable_seqscan = off` on the 2-connection poll pool in `build_poll_pool`, next to the existing `force_generic_plan` and `enable_bitmapscan = off` session GUCs.
> 
> Under a generic plan with near-empty stats and bloated pending indexes, Postgres was choosing a full heap seq scan for each per-type LATERAL probe (~57 per poll). That produced a backlog-independent idle floor (~3,192 shared blocks/call). Forcing index access drops that to ~59 blocks/call and stays at parity in claiming regimes. The main app pool is untouched.
> 
> Adds a narrow `EXPLAIN` regression test that asserts no `Seq Scan on job_executions` under those GUCs, and documents the pin in `PERFORMANCE.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 465bb1feef897c3fddb05c121f9848a17fde73d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->