### PR TITLE
test: gate instantly-completing runners so a claim-path speedup can't delete the row under an assertion

### DIFF
--- a/tests/notify_suppression.rs
+++ b/tests/notify_suppression.rs
@@ -16,12 +16,44 @@ use job::{
     JobType, Jobs,
 };
 use serde::{Deserialize, Serialize};
+use std::sync::Arc;
 use std::time::Duration;
+use tokio::sync::Semaphore;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct Cfg;
 
-struct NoopRunner;
+/// Holds a runner inside `run` until the test opens the gate.
+///
+/// An execution row exists iff its job is pending/parked/running -- it is
+/// DELETED on terminal. So a test that spawns an instantly-completing job
+/// and then reads that row is racing its own job: claim -> dispatch -> run
+/// -> complete -> delete can finish first, and the read then fails with
+/// "no rows returned by a query that expected to return at least one row"
+/// (or, for the scalar-subquery reads below, a NULL that will not decode)
+/// rather than as any assertion. The window is the claim-to-completion
+/// latency, so every improvement to the claim path narrows it; #180's
+/// `enable_seqscan` pin narrowed it enough to make this a CI failure.
+/// Gating the runner removes the race outright rather than widening the
+/// window again: the row cannot reach terminal, so it cannot be deleted.
+///
+/// A `Semaphore` rather than a `Notify` handshake: these types can have
+/// more than one row in flight, and permits added BEFORE a runner parks
+/// still release it, so a dispatch that lands late cannot strand
+/// `shutdown()`.
+type Gate = Arc<Semaphore>;
+
+fn closed_gate() -> Gate {
+    Arc::new(Semaphore::new(0))
+}
+
+fn open(gate: &Gate) {
+    gate.add_permits(1024);
+}
+
+struct NoopRunner {
+    gate: Option<Gate>,
+}
 
 #[async_trait]
 impl JobRunner for NoopRunner {
@@ -29,6 +61,9 @@ impl JobRunner for NoopRunner {
         &self,
         _current_job: CurrentJob,
     ) -> Result<JobCompletion, Box<dyn std::error::Error>> {
+        if let Some(gate) = &self.gate {
+            let _permit = gate.acquire().await?;
+        }
         Ok(JobCompletion::Complete)
     }
 }
@@ -41,6 +76,9 @@ struct NoopInitializer {
     /// units than the backlog it's choosing from, so it deterministically
     /// picks the OLDEST due row rather than whichever row a test just spawned.
     max_concurrent_per_process: Option<usize>,
+    /// `Some` for every test that asserts on this type's execution row:
+    /// see [`Gate`].
+    gate: Option<Gate>,
 }
 
 impl JobInitializer for NoopInitializer {
@@ -59,7 +97,9 @@ impl JobInitializer for NoopInitializer {
         _job: &Job,
         _: JobSpawner<Self::Config>,
     ) -> Result<Box<dyn JobRunner>, Box<dyn std::error::Error>> {
-        Ok(Box::new(NoopRunner))
+        Ok(Box::new(NoopRunner {
+            gate: self.gate.clone(),
+        }))
     }
 }
 
@@ -115,10 +155,12 @@ async fn self_claimed_spawn_suppresses_its_own_notify() -> anyhow::Result<()> {
     let config = JobSvcConfig::builder().pool(pool.clone()).build().unwrap();
     let mut jobs = Jobs::init(config).await?;
     let jt = job_type("notify-suppress-claimed");
+    let gate = closed_gate();
     let spawner = jobs.add_initializer(NoopInitializer {
         job_type: jt.clone(),
         short_circuit: true,
         max_concurrent_per_process: None,
+        gate: Some(Arc::clone(&gate)),
     });
     jobs.start_poll().await?;
 
@@ -143,6 +185,8 @@ async fn self_claimed_spawn_suppresses_its_own_notify() -> anyhow::Result<()> {
         "a self-claimed spawn must not also notify: {stray:?}"
     );
 
+    // Opened before `shutdown()`, which drains running jobs.
+    open(&gate);
     jobs.shutdown().await?;
     Ok(())
 }
@@ -167,7 +211,11 @@ async fn unclaimed_spawn_still_notifies() -> anyhow::Result<()> {
     let spawner = jobs.add_initializer(NoopInitializer {
         job_type: jt.clone(),
         short_circuit: false,
+        // No gate needed: with no poller there is nothing to dispatch this
+        // row, so it stays `pending` and is never deleted -- the same
+        // property the test relies on for its own precondition.
         max_concurrent_per_process: None,
+        gate: None,
     });
     // No `start_poll()`: no poller, no `ClaimHook`, nothing to suppress with.
 
@@ -213,10 +261,12 @@ async fn spawn_not_itself_claimed_still_notifies_even_though_type_was_claimed_fr
     let config = JobSvcConfig::builder().pool(pool.clone()).build().unwrap();
     let mut jobs = Jobs::init(config).await?;
     let jt = job_type("notify-older-backlog");
+    let gate = closed_gate();
     let spawner = jobs.add_initializer(NoopInitializer {
         job_type: jt.clone(),
         short_circuit: true,
         max_concurrent_per_process: Some(1),
+        gate: Some(Arc::clone(&gate)),
     });
     jobs.start_poll().await?;
 
@@ -269,6 +319,10 @@ async fn spawn_not_itself_claimed_still_notifies_even_though_type_was_claimed_fr
         "the newer row is un-claimed and un-notified -- stuck until the next poll wake: {found:?}"
     );
 
+    // Holding the older row also pins the cap-1 slot, which is what keeps
+    // `newer_state == "pending"` a fact rather than a race: the newer row
+    // cannot be admitted while the older one is in flight.
+    open(&gate);
     jobs.shutdown().await?;
     Ok(())
 }

--- a/tests/parked_rows.rs
+++ b/tests/parked_rows.rs
@@ -15,7 +15,36 @@ use job::{
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
-use tokio::sync::Notify;
+use tokio::sync::{Notify, Semaphore};
+
+/// Holds a runner inside `run` until the test opens the gate.
+///
+/// An execution row exists iff its job is pending/parked/running -- it is
+/// DELETED on terminal. So any test that spawns an instantly-completing job
+/// and then reads that row is racing its own job: claim -> dispatch -> run
+/// -> complete -> delete can finish before the read, and the read then
+/// fails with "no rows returned by a query that expected to return at least
+/// one row" rather than any assertion. The window is exactly the
+/// claim-to-completion latency, so every improvement to the claim path
+/// (#177's type-leading index, #180's `enable_seqscan` pin) narrows it;
+/// #180 narrowed it enough to turn this into a reproducible CI failure.
+/// Gating the runner removes the race outright instead of widening the
+/// window again: the row cannot reach terminal, so it cannot be deleted,
+/// so the assertion reads exactly the state the code under test produced.
+///
+/// A `Semaphore` rather than the `Notify` handshake `HoldableRunner` uses:
+/// these types can have more than one row in flight, and permits added
+/// BEFORE a runner parks still release it, so a dispatch that lands late
+/// cannot strand a test's `shutdown()`.
+type Gate = Arc<Semaphore>;
+
+fn closed_gate() -> Gate {
+    Arc::new(Semaphore::new(0))
+}
+
+fn open(gate: &Gate) {
+    gate.add_permits(1024);
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct Cfg;
@@ -378,10 +407,14 @@ struct ImmediateInitializer {
     job_type: JobType,
     completed: Arc<Notify>,
     short_circuit: bool,
+    /// `Some` for every test that asserts on this type's execution row:
+    /// see [`Gate`]. `None` completes immediately, as the name suggests.
+    gate: Option<Gate>,
 }
 
 struct ImmediateRunner {
     completed: Arc<Notify>,
+    gate: Option<Gate>,
 }
 
 #[async_trait]
@@ -390,7 +423,12 @@ impl JobRunner for ImmediateRunner {
         &self,
         _current_job: CurrentJob,
     ) -> Result<JobCompletion, Box<dyn std::error::Error>> {
+        // Before the gate, so `completed` still proves the runner body ran
+        // even while it is being held.
         self.completed.notify_one();
+        if let Some(gate) = &self.gate {
+            let _permit = gate.acquire().await?;
+        }
         Ok(JobCompletion::Complete)
     }
 }
@@ -410,6 +448,7 @@ impl JobInitializer for ImmediateInitializer {
     ) -> Result<Box<dyn JobRunner>, Box<dyn std::error::Error>> {
         Ok(Box::new(ImmediateRunner {
             completed: Arc::clone(&self.completed),
+            gate: self.gate.clone(),
         }))
     }
 }
@@ -428,10 +467,12 @@ async fn short_circuit_spawn_lands_running_immediately_on_commit() -> anyhow::Re
     let mut jobs = Jobs::init(config).await?;
 
     let completed = Arc::new(Notify::new());
+    let gate = closed_gate();
     let spawner = jobs.add_initializer(ImmediateInitializer {
         job_type: job_type("short-circuit-immediate"),
         completed: Arc::clone(&completed),
         short_circuit: true,
+        gate: Some(Arc::clone(&gate)),
     });
     jobs.start_poll().await?;
 
@@ -452,6 +493,8 @@ async fn short_circuit_spawn_lands_running_immediately_on_commit() -> anyhow::Re
         "a running row must be owned by an instance"
     );
 
+    // The row has been observed; let it reach terminal (and be deleted).
+    open(&gate);
     let outcome = jobs
         .handle(id)
         .await_completion(std::time::Duration::from_secs(10))
@@ -476,10 +519,12 @@ async fn short_circuit_disabled_lands_pending() -> anyhow::Result<()> {
     let mut jobs = Jobs::init(config).await?;
 
     let completed = Arc::new(Notify::new());
+    let gate = closed_gate();
     let spawner = jobs.add_initializer(ImmediateInitializer {
         job_type: job_type("short-circuit-disabled"),
         completed,
         short_circuit: false,
+        gate: Some(Arc::clone(&gate)),
     });
     jobs.start_poll().await?;
 
@@ -497,6 +542,10 @@ async fn short_circuit_disabled_lands_pending() -> anyhow::Result<()> {
     // The poll loop may independently win a race to claim it right after
     // commit; what matters is that it never lands `running` directly from
     // the spawn's own transaction, the way a short-circuited type would.
+    // `running` is only reachable here via that claim, which is why the
+    // gate above is what keeps this readable at all: without it the row is
+    // deleted on completion and the read fails outright.
+    open(&gate);
 
     Ok(())
 }
@@ -511,10 +560,12 @@ async fn spawn_yields_to_an_older_pending_row_of_the_same_type() -> anyhow::Resu
     let mut jobs = Jobs::init(config).await?;
 
     let jt = job_type("fairness");
+    let gate = closed_gate();
     let spawner = jobs.add_initializer(ImmediateInitializer {
         job_type: jt.clone(),
         completed: Arc::new(Notify::new()),
         short_circuit: true,
+        gate: Some(Arc::clone(&gate)),
     });
     jobs.start_poll().await?;
 
@@ -574,6 +625,11 @@ async fn spawn_yields_to_an_older_pending_row_of_the_same_type() -> anyhow::Resu
         "the OLDER due row must be the one the spawn's own claim served \
          (new_id is {new_state})"
     );
+    // Both rows are read as scalar subqueries, so a deleted row would
+    // arrive as NULL and fail to decode into `String` rather than as a
+    // missing row -- same race, different symptom. The gate keeps both
+    // alive for the snapshot.
+    open(&gate);
 
     Ok(())
 }


### PR DESCRIPTION
## The failure

CI went red on `0.13.4-dev` (builds [216](https://ci.galoy.io/teams/dev/pipelines/job/jobs/tests/builds/216) / [217](https://ci.galoy.io/teams/dev/pipelines/job/jobs/tests/builds/217), both on `5e9bd77`) with `Error: no rows returned by a query that expected to return at least one row` — **not** an assertion failure:

| build | test |
|---|---|
| 216 (attempt 1) | `notify_suppression::self_claimed_spawn_suppresses_its_own_notify` |
| 216 (attempt 2) | `parked_rows::short_circuit_disabled_lands_pending` |
| 217 | `parked_rows::short_circuit_disabled_lands_pending` |

## Root cause — in the tests, not the poller

An execution row exists **iff** its job is pending/parked/running; it is DELETED on terminal ("liveness is structural"). These tests spawn a job whose runner completes instantly, then read that row with `fetch_one` — so they race their own job:

```
spawn returns ──▶ claim ──▶ dispatch ──▶ run ──▶ complete ──▶ DELETE
                     └────────── the test's read must land in here ──────────┘
```

The window is exactly the claim-to-completion latency, so **every** claim-path improvement narrows it. #180's `enable_seqscan` pin narrowed it enough to close before the read on CI's fresh database. (#177 narrowed it before that; #179 fixed two neighbouring flakes in this same family.)

Confirmed directly rather than inferred: inserting a 300 ms delay before the read reproduces the CI error **verbatim, 3/3**.

Two more tests carry the same race with a different symptom — `spawn_yields_to_an_older_pending_row_of_the_same_type` and `spawn_not_itself_claimed_still_notifies_even_though_type_was_claimed_from` read via scalar subqueries, so a deleted row arrives as NULL and fails to decode into `String` rather than as a missing row. Fixed here too, before they redden CI on their own.

## Fix

Gate the runner inside `run` until the test has taken its snapshot — the same shape `HoldableRunner` already uses in `parked_rows.rs` to hold a queue slot open. This **removes** the race rather than widening the window: the row cannot reach terminal, so it cannot be deleted, so each assertion reads exactly the state the code under test produced.

A `Semaphore` rather than `Notify`: these types can have more than one row in flight, and permits added *before* a runner parks still release it, so a dispatch landing late cannot strand `shutdown()`.

`unclaimed_spawn_still_notifies` needs no gate and gets none — it starts no poller, the same property its own precondition already relies on.

**Nothing is weakened.** Every existing assertion is unchanged. In `spawn_not_itself_claimed_...` the gate additionally makes `newer_state == "pending"` a fact rather than a race, since holding the older row pins the cap-1 slot.

## Verification

- **Race closed, not narrowed:** with the gate, a **1500 ms** delay (5× what failed 3/3 before) passes **3/3**.
- **Full suite 10×:** zero failures of any of these five tests.
- The one failure remaining locally (6/10) is `batch_error_retries_every_item_and_retries_run_alone` — the residual poller wake-accounting defect that #179 documented and deliberately left unfixed. Its rate is **unchanged** from the pre-fix baseline (5/12), and it is not what CI hit (CI passed it in both 216 and 217).
- `nix flake check --option eval-cache false`: all checks passed (genuine rebuild; `cargo fmt --check` exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change to two integration files; no production job/poller logic is modified.
> 
> **Overview**
> Fixes a CI flake where tests spawn an instantly-completing job then `fetch_one` its `job_executions` row: claim → run → complete → DELETE can finish first, so the read fails with “no rows returned” (or a NULL scalar) rather than an assertion.
> 
> `NoopRunner` / `ImmediateRunner` now optionally park on a closed `Semaphore` until the test has snapshotted state, then `open` the gate before `shutdown()`. Assertions are unchanged. Tests with no poller (nothing can dispatch/delete the row) stay ungated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 927163e574076df070755222aa47599dde65e299. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->