### PR TITLE
docs(batched): lead with the observed single-item-batch behaviour

### DIFF
--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -245,10 +245,44 @@ promoted normally) waits for the ordinary poll.
   of row count, so a reservation maps onto a batched type unchanged; the
   claim uses `limit = max_batch_size` and excludes `attempt_index > 1` rows
   (retries always run alone, mirroring how `dispatch_batches` splits an
-  ordinary poll claim). Partial batches under light load are already normal
-  behavior — there is no linger and no minimum — and under sustained load a
+  ordinary poll claim).
+
+  **What this costs, concretely: with spare capacity, each separately
+  committed spawn dispatches as its own single-item batch.** The spawn
+  reserves a slot and claims the instant it commits, so the next spawn finds
+  nothing left to batch with — at 2 items with 2 free slots, `run_batch`
+  never sees `N > 1`. Two teams reached this edge independently: it was
+  confirmed with instrumentation on lana PR #8414 while writing a batched
+  test, and it is pinned here by
+  `separately_committed_spawns_each_dispatch_as_their_own_batch`.
+
+  This is the intended trade — latency now, at the cost of batching that only
+  pays off when work is queueing. There is no linger and no minimum. Under
+  sustained load the slots are busy, spawns stop short-circuiting, and a
   completion's recycle claims a full batch in one statement, because the
   backlog is deep at exactly that moment.
+
+  **Batch formation is governed by the transaction boundary, not by
+  `short_circuit()`.** Items that become due in one transaction are claimed by
+  one claim statement and handed to one `run_batch` call — so `spawn_all`, or
+  several `spawn_in_op` calls sharing one `op`, forms a batch on the fast path
+  itself, with the poller running and capacity free. That is also the
+  affordance for *testing* a multi-item `run_batch`: it needs no configuration
+  change, and it is deterministic by construction, since the claim is a later
+  statement in the same transaction as the inserts and no other claimant can
+  observe the rows unclaimed. Pinned by
+  `one_transaction_forms_one_batch_despite_spare_capacity`.
+
+  Setting `short_circuit()` to `false` in a test-only initializer is **not**
+  the lever it looks like. Separate spawns each wake the poller through the
+  ordinary notify path and still arrive one per batch, so it does not even
+  produce `N > 1`; and the flag is read once at registration
+  (`JobRegistry::add_*_initializer`), so flipping it in a test exercises a
+  different configuration than production for no gain. Saturating every batch
+  slot with a blocking runner and spawning behind it does work — the freed
+  slot's recycle claims the queued rows as one batch — but it is strictly more
+  contorted than committing the items together, and it tests the recycle path
+  rather than the spawn path.
 - **Completions recycle into their own type.** `delete_execution_in_op`
   (per job) and `seal`/`fail_batch` (per batch, exactly once per
   `execute_batch` no matter how many sub-outcomes it disposed) hand the

--- a/src/batched.rs
+++ b/src/batched.rs
@@ -22,7 +22,13 @@
 //! # Guidance for implementors
 //!
 //! - A batch of one is the ordinary case under light load — write `run_batch`
-//!   so it is correct for any length, including 1 and 0.
+//!   so it is correct for any length, including 1 and 0. Concretely: with
+//!   `short_circuit` on (the default) and spare capacity, each spawned item
+//!   dispatches as its *own* single-item batch, so at 2 items with 2 free
+//!   slots `run_batch` never sees `N > 1`. To exercise a multi-item batch —
+//!   in production or in a test — commit the items in **one transaction**
+//!   ([`JobSpawner::spawn_all`], or several [`JobSpawner::spawn_in_op`] calls
+//!   sharing one `op`); see [`BatchedJobInitializer::short_circuit`].
 //! - Treat a batch as *equivalent to running its items one at a time, in order,
 //!   inside one transaction* — later items may observe earlier items' writes.
 //! - `queue_id` uniqueness is not the same as entity disjointness: two items
@@ -122,10 +128,18 @@ pub trait BatchedJobInitializer: Send + Sync + 'static {
 
     /// Whether a due-now spawn or completion of this type may take the
     /// head-swap short-circuit path (a batch slot claimed and dispatched
-    /// with no poll in between). See
-    /// [`crate::JobInitializer::short_circuit`] for the full trade-off --
-    /// identical here, just counted in batches (one unit) rather than rows.
-    /// Defaults to `true`.
+    /// with no poll in between). Defaults to `true`.
+    ///
+    /// With it on and spare capacity, **each spawned item dispatches as its
+    /// own single-item batch** -- at 2 items with 2 free slots, `run_batch`
+    /// never sees `N > 1`. To get a multi-item batch (in production or in a
+    /// test), commit the items in **one transaction**:
+    /// [`JobSpawner::spawn_all`](crate::JobSpawner::spawn_all), or several
+    /// [`spawn_in_op`](crate::JobSpawner::spawn_in_op) calls sharing one
+    /// `op`. Turning this flag off does not help. See
+    /// [`crate::JobInitializer::short_circuit`] for the full trade-off and
+    /// the testing recipe -- identical here, just counted in batches (one
+    /// unit) rather than rows.
     fn short_circuit(&self) -> bool {
         true
     }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -59,6 +59,42 @@ pub trait JobInitializer: Send + Sync + 'static {
     /// Defaults to `true`. Override to `false` for a type that would rather
     /// never pay the extra claim statement and always go through the
     /// ordinary poll instead.
+    ///
+    /// # What this costs a batched type
+    ///
+    /// With `short_circuit` on and spare capacity, **each spawned item
+    /// dispatches as its own single-item batch**: the spawn reserves a slot
+    /// and claims the moment it commits, so the next spawn finds nothing left
+    /// to batch with. At 2 items with 2 free slots,
+    /// [`run_batch`](crate::BatchedJobRunner::run_batch) never sees `N > 1`.
+    /// (Confirmed with instrumentation on lana PR #8414, and pinned here by
+    /// `separately_committed_spawns_each_dispatch_as_their_own_batch`.)
+    ///
+    /// This is the intended trade: latency now, at the cost of the batching
+    /// that only pays off when work is actually queueing. Under sustained
+    /// load the slots are busy, spawns stop short-circuiting, and the backlog
+    /// batches normally.
+    ///
+    /// # Getting `N > 1` in a test
+    ///
+    /// Batch formation is governed by the **transaction boundary**, not by
+    /// this flag: items that become due in one transaction are claimed by one
+    /// claim statement and handed to one `run_batch` call. So spawn them
+    /// together — [`JobSpawner::spawn_all`](crate::JobSpawner::spawn_all), or
+    /// several [`spawn_in_op`](crate::JobSpawner::spawn_in_op) calls sharing
+    /// one `op` — and the batch forms on the short-circuit path itself, with
+    /// the production configuration untouched and the poller running with
+    /// spare capacity. It is deterministic by construction: the claim is a
+    /// later statement in the same transaction as the inserts, so no other
+    /// claimant can observe the rows unclaimed. Pinned by
+    /// `one_transaction_forms_one_batch_despite_spare_capacity`.
+    ///
+    /// Setting `short_circuit()` to `false` in a test-only initializer does
+    /// **not** help, and is not the lever it looks like: separate spawns each
+    /// wake the poller through the ordinary notify path and still arrive one
+    /// per batch. Worse, the flag is read once at registration
+    /// (`JobRegistry::add_*_initializer`), so a test that flips it exercises a
+    /// different configuration than production for no gain.
     fn short_circuit(&self) -> bool {
         true
     }

--- a/tests/batched_job.rs
+++ b/tests/batched_job.rs
@@ -219,6 +219,126 @@ async fn batching_actually_groups_jobs() -> anyhow::Result<()> {
     Ok(())
 }
 
+/// With the poller running and a batch slot free, each *separately committed*
+/// spawn short-circuits on its own: it reserves a slot and claims immediately,
+/// so the next spawn finds nothing left to batch with. Two spawns in two
+/// transactions therefore produce two batches of one — `run_batch` never sees
+/// `len() > 1`, no matter how close together they arrive.
+///
+/// This is the behaviour a downstream adopter hits first when trying to write
+/// a multi-item `run_batch` test (observed independently on lana PR #8414).
+/// The companion test below shows the affordance that does form a batch.
+#[tokio::test]
+async fn separately_committed_spawns_each_dispatch_as_their_own_batch() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let config = JobSvcConfig::builder().pool(pool).build().unwrap();
+    let mut jobs = Jobs::init(config).await?;
+
+    let log = Arc::new(Mutex::new(BatchLog::default()));
+    let spawner = jobs.add_batched_initializer(RecordingInitializer {
+        job_type: JobType::new("batched-separate-commits"),
+        log: Arc::clone(&log),
+        max_batch_size: 25,
+    });
+    jobs.start_poll().await?;
+
+    // Two spawns, two transactions, ample free capacity.
+    let first = JobId::new();
+    let second = JobId::new();
+    spawner
+        .spawn(
+            first,
+            BatchConfig {
+                label: "first".to_string(),
+            },
+        )
+        .await?;
+    spawner
+        .spawn(
+            second,
+            BatchConfig {
+                label: "second".to_string(),
+            },
+        )
+        .await?;
+
+    let outcomes = jobs
+        .handles(vec![first, second])
+        .await_all(Duration::from_secs(30))
+        .await?;
+    assert!(
+        outcomes
+            .iter()
+            .all(|o| o.state() == JobTerminalState::Completed)
+    );
+
+    let log = log.lock().await;
+    assert_eq!(
+        log.sizes,
+        vec![1, 1],
+        "each separately committed spawn should have short-circuited into its \
+         own single-item batch"
+    );
+    Ok(())
+}
+
+/// Items that become due in **one transaction** are claimed by one claim
+/// statement and handed to one `run_batch` call — the batch forms on the
+/// short-circuit fast path itself, with the production `short_circuit()`
+/// default left alone and the poller running with spare capacity.
+///
+/// This is the affordance for testing a multi-item `run_batch`: batch
+/// formation is governed by the transaction boundary, not by `short_circuit()`.
+/// Deterministic by construction — the claim is a later statement in the same
+/// transaction as the inserts, so no other claimant can see the rows unclaimed
+/// and there is nothing to race.
+#[tokio::test]
+async fn one_transaction_forms_one_batch_despite_spare_capacity() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let config = JobSvcConfig::builder().pool(pool).build().unwrap();
+    let mut jobs = Jobs::init(config).await?;
+
+    let log = Arc::new(Mutex::new(BatchLog::default()));
+    let spawner = jobs.add_batched_initializer(RecordingInitializer {
+        job_type: JobType::new("batched-one-transaction"),
+        log: Arc::clone(&log),
+        max_batch_size: 25,
+    });
+    jobs.start_poll().await?;
+
+    // Same two items as the test above, same free capacity — the only
+    // difference is that they commit together.
+    let specs: Vec<JobSpec<BatchConfig>> = ["first", "second"]
+        .into_iter()
+        .map(|label| {
+            JobSpec::new(
+                JobId::new(),
+                BatchConfig {
+                    label: label.to_string(),
+                },
+            )
+        })
+        .collect();
+    let ids: Vec<JobId> = specs.iter().map(|s| s.id).collect();
+    spawner.spawn_all(specs).await?;
+
+    let outcomes = jobs.handles(ids).await_all(Duration::from_secs(30)).await?;
+    assert!(
+        outcomes
+            .iter()
+            .all(|o| o.state() == JobTerminalState::Completed)
+    );
+
+    let log = log.lock().await;
+    assert_eq!(
+        log.sizes,
+        vec![2],
+        "two items committed in one transaction should reach run_batch as a \
+         single batch of 2"
+    );
+    Ok(())
+}
+
 #[tokio::test]
 async fn max_batch_size_is_respected() -> anyhow::Result<()> {
     let pool = helpers::init_pool().await?;


### PR DESCRIPTION
## The question

> Can a downstream adopter, **today, on job 0.13.3**, write a test that exercises their own `run_batch` with **N>1 in a single call**, **without changing the production configuration under test**?

**Answer: yes.** A clean affordance exists. It is not an API gap — but it was undocumented, and the route everyone reaches for first (`short_circuit() -> false`) does not work at all.

Established by writing and running the tests, not by reading code. Every route below was run 15–30× on live PG; every result was identical on every run.

## Routes tried

| # | Route | Observed `run_batch` sizes | Works? | Deterministic? | Production config? |
|---|---|---|---|---|---|
| — | **Baseline** — poller running, spare capacity, 2 separate spawns | `[1, 1]` | reproduces the lana observation | 30/30 | yes |
| (a) | `short_circuit() -> false`, 2 separate spawns | `[1, 1]` | **NO** | 30/30 | no |
| (a2) | `short_circuit() -> false`, 2 spawns in **one** op | `[2]` | yes | 30/30 | no — and the flag is doing nothing (see (c)) |
| (b) | Slot saturation (`max_concurrent = 1`, blocking runner, spawn behind it, release) | `[1, 2]` | yes | 30/30 | yes, but contorted |
| **(c)** | **2 items committed in ONE transaction** (`spawn_all`, poller running, capacity free) | **`[2]`** | **yes** | **30/30** | **yes** |
| (c2) | 2 × `spawn_in_op` sharing one `op` | `[2]` | yes | 30/30 | yes |
| (c3) | `max_batch_size = 3`, `spawn_all(7)` in one op | `[3, 3, 1]` | yes | 15/15 | yes |

### (a) `short_circuit() -> false` — does not work, and is the wrong lever

This is the headline negative result. It does not merely carry the "different configuration" caveat — **it does not produce `N > 1` at all.** With the flag off, separate spawns each wake the poller through the ordinary notify path, so each still arrives as its own poll and its own single-item batch: `[1, 1]`, 30/30.

The registration-time caveat (`registry.rs` bakes `short_circuit_disabled` in at `add_*_initializer`) is therefore moot — but for the record it would have been **merely a caveat, not fatal**: `run_batch`'s body is identical on both paths, and both `dispatch_batch_from_reservation` and the ordinary poll build the same `RawBatchItem`s from the same claimed rows. Only *how items arrive* differs. That caveat never gets exercised, because the route fails first.

(a2) is the proof that the flag is irrelevant: with the flag off *and* one transaction you get `[2]` — exactly what (c) gives with the flag left at its production default.

### (b) Slot saturation — works, deterministically, but is strictly worse than (c)

Saturating the single batch slot with a blocking runner and spawning behind it does form a batch: the freed slot's completion-recycle claims the queued rows in one statement → `[1, 2]`, 30/30.

Determinism is real, not luck, and needs **no sleeps** (per the standing rule — memories `019ffec4` / `01a00f0d`): the test polls runner state for the "blocker is executing" handshake, and the two follow-up spawns commit *before* the release flag is set, so the recycle claim cannot observe them partially. But it needs a blocking runner and a hand-tuned `max_concurrent_per_process`, and it tests the **recycle** path rather than the **spawn** path. Not recommended; documented as a fallback only.

### (c) One transaction — the affordance

**Batch formation is governed by the transaction boundary, not by `short_circuit()`.**

`ExecutionInsertHook` reports how many due-now rows landed pending per type; `ClaimHook::pre_commit` converts that into `n_due.div_ceil(max_batch_size)` reservations and issues **one** `claim_due_heads_in_op` per type, chunking the result into batches. So N items committed together (N ≤ `max_batch_size`) are claimed by one statement and handed to one `run_batch` call — on the short-circuit fast path itself, with the poller running and capacity free.

It is deterministic **by construction**, not by timing: the claim is a later statement in the *same* transaction as the inserts, so no other claimant can ever observe those rows unclaimed. There is nothing to race.

`spawn_all`, or several `spawn_in_op` calls sharing one `op`, both work. (c3) confirms the reservation arithmetic scales as read: 7 items at `max_batch_size = 3` with 2 slots → `[3, 3, 1]` (two full batches short-circuited, the 7th row left pending for the ordinary poll).

## Test evidence

Two live-PG tests in `tests/batched_job.rs`, pinning both halves of the contract:

- `separately_committed_spawns_each_dispatch_as_their_own_batch` — asserts `[1, 1]`, pinning the observed behaviour the docs now lead with.
- `one_transaction_forms_one_batch_despite_spare_capacity` — asserts `[2]`, pinning the affordance. Same two items, same free capacity as the test above; **the only difference is that they commit together.**

**Revert-to-red verified**, each failing for exactly the right reason:

```
one_transaction_forms_one_batch_despite_spare_capacity  (spawn_all -> separate spawns)
  assertion `left == right` failed: two items committed in one transaction
    should reach run_batch as a single batch of 2
    left: [1, 1]   right: [2]

separately_committed_spawns_each_dispatch_as_their_own_batch  (separate spawns -> spawn_all)
  assertion `left == right` failed: each separately committed spawn should have
    short-circuited into its own single-item batch
    left: [2]      right: [1, 1]
```

Both tests: 20/20 green in isolation, 4/4 green in the full suite.

## Docs changed

`short_circuit()` rustdoc (`src/runner.rs`), `BatchedJobInitializer::short_circuit` + the batched module's implementor guidance (`src/batched.rs`), and PERFORMANCE.md's "Batched types are included" tradeoff bullet.

All four now **lead with the observed behaviour** — "with short_circuit on and spare capacity, each spawned item dispatches as its own single-item batch; at 2 items with 2 free slots, `run_batch` never sees N>1" — before the abstract framing. PERFORMANCE.md previously said only "partial batches under light load are already normal behavior — there is no linger and no minimum", which is true but leaves the reader to derive the concrete case themselves. Two teams reached this edge from opposite directions; the concrete instance belongs first.

Each then documents the testing recipe, and explicitly records that `short_circuit() -> false` is **not** the lever it looks like.

**No production code changed.** No new public API surface.

## Verification

- `cargo fmt`; `git add -A`
- `nix flake check --option eval-cache false -L` → **all checks passed**, genuinely fresh: the clippy derivation hash changed against clean HEAD (`hwp0b91…` → `8kj2j8j…`), so it cannot be a cached false-pass, and the log shows a real 34s `buildPhase` recompiling `job v0.13.4-dev`.
- `cargo doc --all-features` with `RUSTDOCFLAGS=-D warnings` → clean (all new intra-doc links resolve).
- Live PG via `make start-deps`: **162/162 passing, 4 consecutive full-suite runs.**

### Pre-existing flake, unrelated to this PR

`batched_job::batch_error_retries_every_item_and_retries_run_alone` failed one full-suite run (30s `TimedOut`). I stashed these changes and re-ran the suite at clean HEAD: **it failed 2 of 3 runs there too.** It passes 3/3 in isolation. Pre-existing and suite-load-dependent — reported, not fixed here (out of scope).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and two pinning tests only; no runtime, claim, or dispatch logic is modified.
> 
> **Overview**
> Documents that with `short_circuit` on and spare capacity, **each separately committed spawn becomes its own single-item batch** — so `run_batch` never sees `N > 1` at 2 items with 2 free slots. That is the intended latency-vs-batching trade, not a bug.
> 
> Pins both halves of the contract in `tests/batched_job.rs`: separate `spawn`s yield `[1, 1]`; `spawn_all` (one transaction) yields `[2]` with production config and the poller running. Docs now say batch formation is the **transaction boundary**, not `short_circuit()`, and that flipping the flag in tests does not produce multi-item batches.
> 
> No production code or API change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc22680a5254b34a9700fd3e80f6a0a82a747a8c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->